### PR TITLE
Fix unlink error when send message with audio

### DIFF
--- a/backend/src/controllers/MessageController.ts
+++ b/backend/src/controllers/MessageController.ts
@@ -81,8 +81,13 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     if (channel === "whatsapp") {
       await Promise.all(
         medias.map(async (media: Express.Multer.File) => {
-          await SendWhatsAppMedia({ media, ticket });
-          fs.unlinkSync(media.path);
+          try {
+            await SendWhatsAppMedia({ media, ticket, body });
+          } finally {
+            if (fs.existsSync(media.path)) {
+              fs.unlinkSync(media.path);
+            }
+          }
         })
       );
     }


### PR DESCRIPTION
**Description**
This pull request resolves the unlink error that occurs when sending messages with audio, as reported in #320. The issue was caused by improper handling of audio file formats and deletion flows.

**Changes**
- Unified the audio processing function to streamline handling.
- Changed the audio format to use only `.mp3` instead of `.m4a`, ensuring better compatibility.
- Fixed the unlink flow to properly delete audio files after processing.

**Tests**
- Tested audio message sending, ensuring no unlink errors occur.
- Verified that the file deletion flow works as expected.

**Resolves**
- #320 