### PR TITLE
Add chatbotTicketTimeoutAction setting to Options component

### DIFF
--- a/frontend/src/components/Settings/Options.js
+++ b/frontend/src/components/Settings/Options.js
@@ -240,6 +240,11 @@ export default function Options(props) {
       const chatbotTicketTimeout = settings.find((s) => s.key === "chatbotTicketTimeout");
       setChatbotTicketTimeout(chatbotTicketTimeout?.value || "0");
 
+      const chatbotTicketTimeoutAction = settings.find((s) => s.key === "chatbotTicketTimeoutAction");
+      if (chatbotTicketTimeoutAction) {
+        setChatbotTicketTimeoutAction(chatbotTicketTimeoutAction.value);
+      }
+
       const gracePeriod = settings.find((s) => s.key === "gracePeriod");
       setGracePeriod(gracePeriod?.value || 0);
       


### PR DESCRIPTION
Mostrar corretamente a ação escolhida da Ação do timeout do chatbot ao abrir a pagina de configurações. Estava mostrando sempre desativada..


![image](https://github.com/user-attachments/assets/c15a26ce-2bf0-48cf-9e44-60c4b867d667)
