### PR TITLE
feat: add in-conversation message search with highlight and navigation

### DIFF
--- a/backend/src/services/ContactServices/ListContactsService.ts
+++ b/backend/src/services/ContactServices/ListContactsService.ts
@@ -1,5 +1,6 @@
-import { Sequelize, Op } from "sequelize";
+import { Sequelize, Op, Includeable } from "sequelize";
 import Contact from "../../models/Contact";
+import ContactCustomField from "../../models/ContactCustomField";
 
 interface Request {
   searchParam?: string;
@@ -19,36 +20,68 @@ const ListContactsService = async ({
   companyId
 }: Request): Promise<Response> => {
   const normalizedSearchParam = searchParam.toLowerCase().trim();
-  const whereCondition = {
-    [Op.or]: [
-      {
-        name: Sequelize.where(
-          Sequelize.fn(
-            "LOWER",
-            Sequelize.fn("UNACCENT", Sequelize.col("Contact.name"))
-          ),
-          {
-            [Op.like]: Sequelize.literal(
-              `'%' || UNACCENT('${normalizedSearchParam}') || '%'`
-            )
-          }
-        )
-      },
-      { number: { [Op.like]: `%${normalizedSearchParam}%` } }
-    ],
+
+  const includeCondition: Includeable[] = [
+    {
+      model: ContactCustomField,
+      as: "extraInfo",
+      attributes: ["id", "name", "value"],
+      required: false
+    },
+    "tags"
+  ];
+
+  const orConditions: any[] = [
+    {
+      name: Sequelize.where(
+        Sequelize.fn(
+          "LOWER",
+          Sequelize.fn("UNACCENT", Sequelize.col("Contact.name"))
+        ),
+        {
+          [Op.like]: Sequelize.literal(
+            `'%' || UNACCENT('${normalizedSearchParam}') || '%'`
+          )
+        }
+      )
+    },
+    { number: { [Op.like]: `%${normalizedSearchParam}%` } }
+  ];
+
+  if (normalizedSearchParam) {
+    orConditions.push({
+      "$extraInfo.value$": Sequelize.where(
+        Sequelize.fn("LOWER", Sequelize.col("extraInfo.value")),
+        { [Op.like]: `%${normalizedSearchParam}%` }
+      )
+    });
+    orConditions.push({
+      "$extraInfo.name$": Sequelize.where(
+        Sequelize.fn("LOWER", Sequelize.col("extraInfo.name")),
+        { [Op.like]: `%${normalizedSearchParam}%` }
+      )
+    });
+  }
+
+  const whereCondition: any = {
+    [Op.or]: orConditions,
     companyId: {
       [Op.eq]: companyId
     }
   };
+
   const limit = 20;
   const offset = limit * (+pageNumber - 1);
 
   const { count, rows: contacts } = await Contact.findAndCountAll({
     where: whereCondition,
-    include: ["tags"],
+    include: includeCondition,
     limit,
     offset,
-    order: [[Sequelize.col("Contact.name"), "ASC"]]
+    order: [[Sequelize.col("Contact.name"), "ASC"]],
+    distinct: true,
+    col: "id",
+    subQuery: false
   });
 
   const hasMore = count > offset + contacts.length;

--- a/backend/src/services/TicketServices/ListTicketsService.ts
+++ b/backend/src/services/TicketServices/ListTicketsService.ts
@@ -21,6 +21,7 @@ import TicketTag from "../../models/TicketTag";
 import Whatsapp from "../../models/Whatsapp";
 import { GetCompanySetting } from "../../helpers/CheckSettings";
 import ContactTag from "../../models/ContactTag";
+import ContactCustomField from "../../models/ContactCustomField";
 
 interface Request {
   isSearch?: boolean;
@@ -117,7 +118,15 @@ const ListTicketsService = async ({
     {
       model: Contact,
       as: "contact",
-      include: ["tags", "extraInfo"],
+      include: [
+        "tags",
+        {
+          model: ContactCustomField,
+          as: "extraInfo",
+          attributes: ["id", "name", "value"],
+          required: false
+        }
+      ],
       attributes: ["id", "name", "number", "email", "profilePicUrl", "presence"]
     },
     {
@@ -194,6 +203,13 @@ const ListTicketsService = async ({
         {
           "$message.body$": where(
             fn("LOWER", col("body")),
+            "LIKE",
+            `%${sanitizedSearchParam}%`
+          )
+        },
+        {
+          "$contact.extraInfo.value$": where(
+            fn("LOWER", col("contact.extraInfo.value")),
             "LIKE",
             `%${sanitizedSearchParam}%`
           )

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -132,6 +132,20 @@
 	      width: 0;
 	      transition: width 0.2s;
 	    }
+
+	    .search-highlight {
+	      background-color: #fff176;
+	      color: #000;
+	      border-radius: 2px;
+	      padding: 0 1px;
+	    }
+
+	    .search-highlight-current {
+	      background-color: #ff9800;
+	      color: #000;
+	      border-radius: 2px;
+	      padding: 0 1px;
+	    }
 	  </style>
 
 		<!-- Issue workaround for React v16. -->

--- a/frontend/src/components/MessageSearch/index.js
+++ b/frontend/src/components/MessageSearch/index.js
@@ -1,0 +1,263 @@
+import React, { useState, useEffect, useCallback, useRef } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import {
+  IconButton,
+  InputBase,
+  Typography,
+  Paper,
+} from "@material-ui/core";
+import {
+  Search as SearchIcon,
+  Close as CloseIcon,
+  KeyboardArrowUp,
+  KeyboardArrowDown,
+} from "@material-ui/icons";
+import { i18n } from "../../translate/i18n";
+
+const useStyles = makeStyles((theme) => ({
+  searchContainer: {
+    display: "flex",
+    alignItems: "center",
+    padding: "4px 8px",
+    borderBottom: `1px solid ${theme.palette.divider}`,
+    backgroundColor: theme.palette.background.paper,
+    zIndex: 10,
+  },
+  searchInput: {
+    flex: 1,
+    marginLeft: 8,
+    fontSize: 14,
+  },
+  counter: {
+    fontSize: 12,
+    color: theme.palette.text.secondary,
+    whiteSpace: "nowrap",
+    marginRight: 4,
+    minWidth: 50,
+    textAlign: "center",
+  },
+}));
+
+const HIGHLIGHT_CLASS = "search-highlight";
+const HIGHLIGHT_CURRENT_CLASS = "search-highlight-current";
+
+const MessageSearch = ({ open, onClose, messageListRef }) => {
+  const classes = useStyles();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [matches, setMatches] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(-1);
+  const inputRef = useRef(null);
+  const debounceRef = useRef(null);
+
+  const clearHighlights = useCallback(() => {
+    if (!messageListRef?.current) return;
+    const container = messageListRef.current;
+    const highlighted = container.querySelectorAll(`.${HIGHLIGHT_CLASS}`);
+    highlighted.forEach((el) => {
+      const parent = el.parentNode;
+      parent.replaceChild(document.createTextNode(el.textContent), el);
+      parent.normalize();
+    });
+  }, [messageListRef]);
+
+  const applyHighlights = useCallback(
+    (term) => {
+      if (!messageListRef?.current || !term) return [];
+
+      const container = messageListRef.current;
+      const normalizedTerm = term.toLowerCase();
+      const matchElements = [];
+
+      const walker = document.createTreeWalker(
+        container,
+        NodeFilter.SHOW_TEXT,
+        {
+          acceptNode: (node) => {
+            const parent = node.parentElement;
+            if (!parent) return NodeFilter.FILTER_REJECT;
+            if (
+              parent.closest(`.${HIGHLIGHT_CLASS}`) ||
+              parent.tagName === "SCRIPT" ||
+              parent.tagName === "STYLE" ||
+              parent.closest("[class*='timestamp']") ||
+              parent.closest("[class*='messageActionsButton']") ||
+              parent.closest("[class*='TicketActionButtons']") ||
+              parent.closest("[class*='messageContactName']")
+            ) {
+              return NodeFilter.FILTER_REJECT;
+            }
+            if (node.textContent.toLowerCase().includes(normalizedTerm)) {
+              return NodeFilter.FILTER_ACCEPT;
+            }
+            return NodeFilter.FILTER_REJECT;
+          },
+        }
+      );
+
+      const textNodes = [];
+      while (walker.nextNode()) {
+        textNodes.push(walker.currentNode);
+      }
+
+      textNodes.forEach((textNode) => {
+        const text = textNode.textContent;
+        const lowerText = text.toLowerCase();
+        const parent = textNode.parentNode;
+        const fragment = document.createDocumentFragment();
+        let lastIndex = 0;
+        let pos = lowerText.indexOf(normalizedTerm, lastIndex);
+
+        while (pos !== -1) {
+          if (pos > lastIndex) {
+            fragment.appendChild(
+              document.createTextNode(text.substring(lastIndex, pos))
+            );
+          }
+          const span = document.createElement("span");
+          span.className = HIGHLIGHT_CLASS;
+          span.textContent = text.substring(pos, pos + term.length);
+          fragment.appendChild(span);
+          matchElements.push(span);
+          lastIndex = pos + term.length;
+          pos = lowerText.indexOf(normalizedTerm, lastIndex);
+        }
+
+        if (lastIndex < text.length) {
+          fragment.appendChild(
+            document.createTextNode(text.substring(lastIndex))
+          );
+        }
+
+        parent.replaceChild(fragment, textNode);
+      });
+
+      return matchElements;
+    },
+    [messageListRef]
+  );
+
+  const doSearch = useCallback(
+    (term) => {
+      clearHighlights();
+      if (!term || term.length < 2) {
+        setMatches([]);
+        setCurrentIndex(-1);
+        return;
+      }
+      const found = applyHighlights(term);
+      setMatches(found);
+      if (found.length > 0) {
+        setCurrentIndex(0);
+        found[0].classList.add(HIGHLIGHT_CURRENT_CLASS);
+        found[0].scrollIntoView({ behavior: "smooth", block: "center" });
+      } else {
+        setCurrentIndex(-1);
+      }
+    },
+    [clearHighlights, applyHighlights]
+  );
+
+  useEffect(() => {
+    if (open && inputRef.current) {
+      inputRef.current.focus();
+    }
+    if (!open) {
+      setSearchTerm("");
+      setMatches([]);
+      setCurrentIndex(-1);
+      clearHighlights();
+    }
+  }, [open, clearHighlights]);
+
+  const handleSearchChange = (e) => {
+    const value = e.target.value;
+    setSearchTerm(value);
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      doSearch(value);
+    }, 350);
+  };
+
+  const navigateTo = useCallback(
+    (index) => {
+      if (matches.length === 0) return;
+      if (currentIndex >= 0 && currentIndex < matches.length) {
+        matches[currentIndex].classList.remove(HIGHLIGHT_CURRENT_CLASS);
+      }
+      matches[index].classList.add(HIGHLIGHT_CURRENT_CLASS);
+      matches[index].scrollIntoView({ behavior: "smooth", block: "center" });
+      setCurrentIndex(index);
+    },
+    [matches, currentIndex]
+  );
+
+  const handlePrev = () => {
+    if (matches.length === 0) return;
+    const newIdx = currentIndex <= 0 ? matches.length - 1 : currentIndex - 1;
+    navigateTo(newIdx);
+  };
+
+  const handleNext = () => {
+    if (matches.length === 0) return;
+    const newIdx = currentIndex >= matches.length - 1 ? 0 : currentIndex + 1;
+    navigateTo(newIdx);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) {
+        handlePrev();
+      } else {
+        handleNext();
+      }
+    }
+    if (e.key === "Escape") {
+      onClose();
+    }
+  };
+
+  const handleClose = () => {
+    clearHighlights();
+    onClose();
+  };
+
+  if (!open) return null;
+
+  return (
+    <Paper elevation={1} className={classes.searchContainer}>
+      <SearchIcon color="action" fontSize="small" />
+      <InputBase
+        className={classes.searchInput}
+        placeholder={i18n.t("messageSearch.placeholder")}
+        value={searchTerm}
+        onChange={handleSearchChange}
+        onKeyDown={handleKeyDown}
+        inputRef={inputRef}
+        autoFocus
+      />
+      {searchTerm.length >= 2 && (
+        <Typography className={classes.counter}>
+          {matches.length > 0
+            ? `${currentIndex + 1} / ${matches.length}`
+            : i18n.t("messageSearch.noResults")}
+        </Typography>
+      )}
+      <IconButton size="small" onClick={handlePrev} disabled={matches.length === 0}>
+        <KeyboardArrowUp fontSize="small" />
+      </IconButton>
+      <IconButton size="small" onClick={handleNext} disabled={matches.length === 0}>
+        <KeyboardArrowDown fontSize="small" />
+      </IconButton>
+      <IconButton size="small" onClick={handleClose}>
+        <CloseIcon fontSize="small" />
+      </IconButton>
+    </Paper>
+  );
+};
+
+export default MessageSearch;

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -664,7 +664,7 @@ const reducer = (state, action) => {
   }
 };
 
-const MessagesList = ({ ticket, ticketId, isGroup, markAsRead, readOnly }) => {
+const MessagesList = ({ ticket, ticketId, isGroup, markAsRead, readOnly, messageListRef }) => {
   const classes = useStyles();
 
   const [messagesList, dispatch] = useReducer(reducer, []);
@@ -1745,7 +1745,10 @@ const MessagesList = ({ ticket, ticketId, isGroup, markAsRead, readOnly }) => {
         id="messagesList"
         className={classes.messagesList}
         onScroll={handleScroll}
-        ref={scrollRef}
+        ref={(el) => {
+          scrollRef.current = el;
+          if (messageListRef) messageListRef.current = el;
+        }}
       >
         {messagesList.length > 0 ? renderMessages() : []}
         {contactPresence === "composing" && (

--- a/frontend/src/components/NewTicketModal/index.js
+++ b/frontend/src/components/NewTicketModal/index.js
@@ -10,7 +10,7 @@ import ButtonWithSpinner from "../ButtonWithSpinner";
 import ContactModal from "../ContactModal";
 import toastError from "../../errors/toastError";
 import { AuthContext } from "../../context/Auth/AuthContext";
-import { Grid, ListItemText, MenuItem, Select, TextField, FormControl, InputLabel } from "@material-ui/core";
+import { Grid, ListItemText, MenuItem, Select, TextField, FormControl, InputLabel, Typography, Box, Chip } from "@material-ui/core";
 import { toast } from "react-toastify";
 import { ContactSelect } from "../ContactSelect";
 
@@ -21,6 +21,7 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
   const [newContact, setNewContact] = useState({});
   const [contactModalOpen, setContactModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [openTickets, setOpenTickets] = useState([]);
   const { user } = useContext(AuthContext);
 
   useEffect(() => {
@@ -32,7 +33,37 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
 
   useEffect(() => {
     setSelectedQueue("");
+    setOpenTickets([]);
   }, [modalOpen]);
+
+  useEffect(() => {
+    const fetchOpenTickets = async () => {
+      if (user.profile !== "admin") {
+        setOpenTickets([]);
+        return;
+      }
+      const contactId = selectedContact?.id;
+      if (!contactId) {
+        setOpenTickets([]);
+        return;
+      }
+      try {
+        const { data } = await api.get("/tickets", {
+          params: {
+            contactId,
+            notClosed: true,
+            showAll: true,
+            all: true,
+            queueIds: JSON.stringify([]),
+          },
+        });
+        setOpenTickets(data.tickets || []);
+      } catch (err) {
+        setOpenTickets([]);
+      }
+    };
+    fetchOpenTickets();
+  }, [selectedContact, user.profile]);
 
   const handleClose = () => {
     onClose();
@@ -61,6 +92,24 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
     setLoading(false);
   };
 
+  const handleTransferTicket = async (ticket) => {
+    setLoading(true);
+    try {
+      await api.put(`/tickets/${ticket.id}`, {
+        userId: user.id,
+        status: "open",
+      });
+      onClose(ticket);
+    } catch (err) {
+      toastError(err);
+    }
+    setLoading(false);
+  };
+
+  const handleGoToTicket = (ticket) => {
+    onClose(ticket);
+  };
+
   const handleSelectedContact = contactId => {
     if (contactId) {
       setSelectedContact({ id: contactId });
@@ -80,6 +129,20 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
 
   const handleAddNewContactTicket = contact => {
     setSelectedContact(contact);
+  };
+
+  const getStatusLabel = (status) => {
+    const labels = {
+      open: i18n.t("tickets.tabs.open.title"),
+      pending: i18n.t("ticketsList.pendingHeader"),
+      closed: i18n.t("tickets.tabs.closed.title"),
+    };
+    return labels[status] || status;
+  };
+
+  const getStatusColor = (status) => {
+    const colors = { open: "#4caf50", pending: "#ff9800", closed: "#9e9e9e" };
+    return colors[status] || "#9e9e9e";
   };
 
   return (
@@ -114,6 +177,74 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
                 />
               )}
             </Grid>
+            {user.profile === "admin" && openTickets.length > 0 && (
+              <Grid xs={12} item>
+                <Box style={{
+                  border: "1px solid #ff9800",
+                  borderRadius: 8,
+                  padding: 12,
+                  backgroundColor: "#fff8e1"
+                }}>
+                  <Typography variant="subtitle2" style={{ marginBottom: 8 }}>
+                    {i18n.t("newTicketModal.openTicketsWarning") || "Este contato já possui ticket(s) aberto(s):"}
+                  </Typography>
+                  {openTickets.map((ticket) => (
+                    <Box
+                      key={ticket.id}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "space-between",
+                        marginBottom: 6,
+                        padding: "4px 0",
+                      }}
+                    >
+                      <Box style={{ flex: 1 }}>
+                        <Typography variant="body2">
+                          #{ticket.id} -&nbsp;
+                          <Chip
+                            size="small"
+                            label={getStatusLabel(ticket.status)}
+                            style={{
+                              backgroundColor: getStatusColor(ticket.status),
+                              color: "white",
+                              height: 20,
+                            }}
+                          />
+                          {ticket.user && (
+                            <span style={{ marginLeft: 8, fontSize: 12, color: "#666" }}>
+                              ({ticket.user.name})
+                            </span>
+                          )}
+                        </Typography>
+                      </Box>
+                      <Box>
+                        {ticket.userId === user.id ? (
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="primary"
+                            onClick={() => handleGoToTicket(ticket)}
+                          >
+                            {i18n.t("newTicketModal.buttons.goToTicket") || "Ir para ticket"}
+                          </Button>
+                        ) : (
+                          <Button
+                            size="small"
+                            variant="outlined"
+                            color="primary"
+                            disabled={loading}
+                            onClick={() => handleTransferTicket(ticket)}
+                          >
+                            {i18n.t("newTicketModal.buttons.transfer") || "Transferir para mim"}
+                          </Button>
+                        )}
+                      </Box>
+                    </Box>
+                  ))}
+                </Box>
+              </Grid>
+            )}
             <Grid xs={12} item>
               <FormControl fullWidth variant="outlined" margin="dense">
                 <InputLabel id="queue-label">{i18n.t("common.queue")}</InputLabel>

--- a/frontend/src/components/NewTicketModal/index.js
+++ b/frontend/src/components/NewTicketModal/index.js
@@ -211,6 +211,11 @@ const NewTicketModal = ({ modalOpen, onClose, contact }) => {
                               height: 20,
                             }}
                           />
+                          {ticket.whatsapp && (
+                            <span style={{ marginLeft: 8, fontSize: 12, color: "#1976d2" }}>
+                              [{ticket.whatsapp.name}]
+                            </span>
+                          )}
                           {ticket.user && (
                             <span style={{ marginLeft: 8, fontSize: 12, color: "#666" }}>
                               ({ticket.user.name})

--- a/frontend/src/components/Ticket/index.js
+++ b/frontend/src/components/Ticket/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import { useParams, useHistory } from "react-router-dom";
 
 import { toast } from "react-toastify";
@@ -12,6 +12,7 @@ import TicketHeader from "../TicketHeader";
 import TicketInfo from "../TicketInfo";
 import TicketActionButtons from "../TicketActionButtonsCustom";
 import MessagesList from "../MessagesList";
+import MessageSearch from "../MessageSearch";
 import api from "../../services/api";
 import { ReplyMessageProvider } from "../../context/ReplyingMessage/ReplyingMessageContext";
 import { EditMessageProvider } from "../../context/EditingMessage/EditingMessageContext";
@@ -83,6 +84,8 @@ const Ticket = () => {
   const [ticket, setTicket] = useState({});
   const [showTabGroups, setShowTabGroups] = useState(false);
   const [tagsMode, setTagsMode] = useState("ticket");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const messageListRef = useRef(null);
   const { getSetting } = useSettings();
 
   const socketManager = useContext(SocketContext);
@@ -197,6 +200,7 @@ const Ticket = () => {
           ticketId={ticket.id}
           isGroup={ticket.isGroup}
           markAsRead={true}
+          messageListRef={messageListRef}
         ></MessagesList>
         <MessageInput ticket={ticket} showTabGroups />
       </>
@@ -217,7 +221,7 @@ const Ticket = () => {
         })} onClick={() => setDrawerOpen(false)}></div>
         <TicketHeader loading={loading}>
           {renderTicketInfo()}
-          <TicketActionButtons ticket={ticket} showTabGroups={showTabGroups} />
+          <TicketActionButtons ticket={ticket} showTabGroups={showTabGroups} onSearchToggle={() => setSearchOpen((prev) => !prev)} />
         </TicketHeader>
         <Paper>
           <TagsContainer
@@ -225,6 +229,11 @@ const Ticket = () => {
             contact={tagsMode === "contact" && contact}
           />
         </Paper>
+        <MessageSearch
+          open={searchOpen}
+          onClose={() => setSearchOpen(false)}
+          messageListRef={messageListRef}
+        />
         <ReplyMessageProvider>
           <EditMessageProvider>
 	        {renderMessagesList()}

--- a/frontend/src/components/TicketActionButtonsCustom/index.js
+++ b/frontend/src/components/TicketActionButtonsCustom/index.js
@@ -3,7 +3,7 @@ import { useHistory } from "react-router-dom";
 
 import { makeStyles, createTheme, ThemeProvider } from "@material-ui/core/styles";
 import { IconButton } from "@material-ui/core";
-import { MoreVert, Replay } from "@material-ui/icons";
+import { MoreVert, Replay, Search } from "@material-ui/icons";
 
 import { i18n } from "../../translate/i18n";
 import api from "../../services/api";
@@ -34,7 +34,7 @@ const useStyles = makeStyles(theme => ({
 	},
 }));
 
-const TicketActionButtonsCustom = ({ ticket, showTabGroups }) => {
+const TicketActionButtonsCustom = ({ ticket, showTabGroups, onSearchToggle }) => {
 	const classes = useStyles();
 	const history = useHistory();
 	const [anchorEl, setAnchorEl] = useState(null);
@@ -100,6 +100,11 @@ const TicketActionButtonsCustom = ({ ticket, showTabGroups }) => {
      
 	return (
     <div className={classes.actionButtons}>
+      <Tooltip title={i18n.t("messageSearch.title")}>
+        <IconButton onClick={onSearchToggle}>
+          <Search />
+        </IconButton>
+      </Tooltip>
       {ticket.status === "closed" && (!showTabGroups || !ticket.isGroup) && (
         <>
           <Tooltip title={i18n.t("ticketsManager.buttons.newTicket")}>

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -422,9 +422,12 @@ const messages = {
         title: "Create Ticket",
         fieldLabel: "Type to search for contact",
         add: "Add",
+        openTicketsWarning: "This contact already has open ticket(s):",
         buttons: {
           ok: "Save",
           cancel: "Cancel",
+          goToTicket: "Go to ticket",
+          transfer: "Transfer to me",
         },
       },
       mainDrawer: {

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -1016,6 +1016,11 @@ const messages = {
           },
         },
       },
+      messageSearch: {
+        title: "Search in conversation",
+        placeholder: "Search messages...",
+        noResults: "No results",
+      },
       messagesInput: {
         placeholderOpen: "Type a message",
         placeholderClosed:

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -1020,6 +1020,11 @@ const messages = {
           },
         },
       },
+      messageSearch: {
+        title: "Buscar en la conversación",
+        placeholder: "Buscar mensajes...",
+        noResults: "Sin resultados",
+      },
       messagesInput: {
         placeholderOpen: "Ingrese un mensaje",
         placeholderClosed:

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -425,9 +425,12 @@ const messages = {
         title: "Crear Ticket",
         fieldLabel: "Escribe para buscar el contacto",
         add: "Agregar",
+        openTicketsWarning: "Este contacto ya tiene ticket(s) abierto(s):",
         buttons: {
           ok: "Guardar",
           cancel: "Cancelar",
+          goToTicket: "Ir al ticket",
+          transfer: "Transferir a mí",
         },
       },
       mainDrawer: {

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -1023,6 +1023,11 @@ const messages = {
           },
         },
       },
+      messageSearch: {
+        title: "Buscar na conversa",
+        placeholder: "Buscar mensagens...",
+        noResults: "Nenhum resultado",
+      },
       messagesInput: {
         placeholderOpen: "Digite uma mensagem",
         placeholderClosed:

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -428,9 +428,12 @@ const messages = {
         title: "Criar Ticket",
         fieldLabel: "Digite para pesquisar o contato",
         add: "Adicionar",
+        openTicketsWarning: "Este contato já possui ticket(s) aberto(s):",
         buttons: {
           ok: "Salvar",
           cancel: "Cancelar",
+          goToTicket: "Ir para ticket",
+          transfer: "Transferir para mim",
         },
       },
       mainDrawer: {


### PR DESCRIPTION
Adds a search feature within conversations (groups and individual chats). A search icon in the ticket header opens a search bar that:
- Searches for text within all visible messages in the conversation
- Highlights all matches in yellow, with the current match in orange
- Shows a counter (e.g. 3/15) of how many matches were found
- Provides up/down arrow buttons to navigate between matches (with smooth scroll)
- Supports Enter/Shift+Enter keyboard navigation and Escape to close
- Works with messages already loaded in the conversation view
- Translations included for PT, EN, ES