### PR TITLE
feat(frontend): opção de temas em runtime

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,176 @@ const defaultLogoLight = "/vector/logo.svg";
 const defaultLogoDark = "/vector/logo-dark.svg";
 const defaultLogoFavicon = "/vector/favicon.svg";
 
+const ATTENDITOP_LIGHT = {
+  bg: "#F7F7F4",
+  bgAmbient: "#EEEDE7",
+  surface1: "#FFFFFF",
+  surface2: "#FAFAF7",
+  surface3: "#F2F2EE",
+  border: "rgba(0,0,0,0.08)",
+  text: "#0A0A0A",
+  textMuted: "#565660",
+  textFaint: "#8B8B95",
+  primaryFallback: "#FF7A00",
+  primarySoft: "#FFF4E6",
+  primarySoft2: "rgba(255,122,0,0.22)",
+  chatFromMe: "#FF7A00",
+  chatReceived: "#FFFFFF",
+  chatBackground: "#EFEAE2"
+};
+
+const ATTENDITOP_DARK = {
+  bg: "#161617",
+  bgAmbient: "#101012",
+  surface1: "#1D1E20",
+  surface2: "#242529",
+  surface3: "#2B2D33",
+  border: "rgba(255,255,255,0.10)",
+  text: "#F5F5F6",
+  textMuted: "#C3C3CB",
+  textFaint: "#8E8F98",
+  primaryFallback: "#FF9A2F",
+  primarySoft: "rgba(255,154,47,0.18)",
+  primarySoft2: "rgba(255,154,47,0.32)",
+  chatFromMe: "#FF8A1A",
+  chatReceived: "#242529",
+  chatBackground: "#1A1A1D"
+};
+
+const LEGACY_LIGHT = {
+  bg: "#fafafa",
+  bgAmbient: "#fafafa",
+  surface1: "#ffffff",
+  surface2: "#F3F3F3",
+  surface3: "#e8e8e8",
+  border: "rgba(0,0,0,0.12)",
+  text: "#303030",
+  textMuted: "#687992",
+  textFaint: "#7f8fa6",
+  primaryFallback: "#39ACE7",
+  primarySoft: "rgba(57,172,231,0.14)",
+  primarySoft2: "rgba(57,172,231,0.24)",
+  chatFromMe: "#dcf8c6",
+  chatReceived: "#ffffff",
+  chatBackground: "#f3f3f3"
+};
+
+const LEGACY_DARK = {
+  bg: "#303030",
+  bgAmbient: "#303030",
+  surface1: "#424242",
+  surface2: "#333333",
+  surface3: "#2a2a2a",
+  border: "rgba(255,255,255,0.14)",
+  text: "#ffffff",
+  textMuted: "#d0d0d0",
+  textFaint: "#b4b4b4",
+  primaryFallback: "#39ACE7",
+  primarySoft: "rgba(57,172,231,0.2)",
+  primarySoft2: "rgba(57,172,231,0.34)",
+  chatFromMe: "#005c4b",
+  chatReceived: "#024481",
+  chatBackground: "#333333"
+};
+
+const OCEAN_LIGHT = {
+  bg: "#F3FAFF",
+  bgAmbient: "#E9F5FF",
+  surface1: "#FFFFFF",
+  surface2: "#EEF6FF",
+  surface3: "#E3EFFB",
+  border: "rgba(7,89,133,0.18)",
+  text: "#0F172A",
+  textMuted: "#334155",
+  textFaint: "#64748B",
+  primaryFallback: "#0284C7",
+  primarySoft: "rgba(2,132,199,0.16)",
+  primarySoft2: "rgba(2,132,199,0.32)",
+  chatFromMe: "#0284C7",
+  chatReceived: "#FFFFFF",
+  chatBackground: "#E8F3FC"
+};
+
+const OCEAN_DARK = {
+  bg: "#0B1320",
+  bgAmbient: "#0A111D",
+  surface1: "#111D2E",
+  surface2: "#162335",
+  surface3: "#1B2A40",
+  border: "rgba(125,211,252,0.2)",
+  text: "#E2E8F0",
+  textMuted: "#CBD5E1",
+  textFaint: "#94A3B8",
+  primaryFallback: "#38BDF8",
+  primarySoft: "rgba(56,189,248,0.18)",
+  primarySoft2: "rgba(56,189,248,0.3)",
+  chatFromMe: "#0EA5E9",
+  chatReceived: "#1E293B",
+  chatBackground: "#0F172A"
+};
+
+const GRAPHITE_LIGHT = {
+  bg: "#F5F6F8",
+  bgAmbient: "#ECEEF1",
+  surface1: "#FFFFFF",
+  surface2: "#F1F3F7",
+  surface3: "#E6E9EE",
+  border: "rgba(17,24,39,0.14)",
+  text: "#111827",
+  textMuted: "#4B5563",
+  textFaint: "#6B7280",
+  primaryFallback: "#111827",
+  primarySoft: "rgba(17,24,39,0.1)",
+  primarySoft2: "rgba(17,24,39,0.2)",
+  chatFromMe: "#374151",
+  chatReceived: "#FFFFFF",
+  chatBackground: "#E5E7EB"
+};
+
+const GRAPHITE_DARK = {
+  bg: "#111315",
+  bgAmbient: "#0D0F11",
+  surface1: "#181B20",
+  surface2: "#20242A",
+  surface3: "#2A2F36",
+  border: "rgba(255,255,255,0.13)",
+  text: "#F3F4F6",
+  textMuted: "#D1D5DB",
+  textFaint: "#9CA3AF",
+  primaryFallback: "#9CA3AF",
+  primarySoft: "rgba(156,163,175,0.2)",
+  primarySoft2: "rgba(156,163,175,0.32)",
+  chatFromMe: "#4B5563",
+  chatReceived: "#1F2937",
+  chatBackground: "#111827"
+};
+
+const THEME_VARIANT_TOKENS = {
+  legacy: {
+    light: LEGACY_LIGHT,
+    dark: LEGACY_DARK
+  },
+  attenditop: {
+    light: ATTENDITOP_LIGHT,
+    dark: ATTENDITOP_DARK
+  },
+  ocean: {
+    light: OCEAN_LIGHT,
+    dark: OCEAN_DARK
+  },
+  graphite: {
+    light: GRAPHITE_LIGHT,
+    dark: GRAPHITE_DARK
+  }
+};
+
+const THEME_VARIANT_LABELS = {
+  legacy: "Modelo Clássico",
+  attenditop: "AtendiTop",
+  ocean: "Ocean",
+  graphite: "Graphite"
+};
+
 function useViewportHeight() {
   useEffect(() => {
     const setVh = () => {
@@ -51,8 +221,16 @@ const App = () => {
   const prefersDarkMode = !!window.matchMedia("(prefers-color-scheme: dark)")
     .matches;
   const preferredTheme = window.localStorage.getItem("preferredTheme");
+  const preferredThemeVariant = window.localStorage.getItem(
+    "preferredThemeVariant"
+  );
   const [mode, setMode] = useState(
     preferredTheme ? preferredTheme : prefersDarkMode ? "dark" : "light"
+  );
+  const [themeVariant, setThemeVariant] = useState(
+    preferredThemeVariant && THEME_VARIANT_TOKENS[preferredThemeVariant]
+      ? preferredThemeVariant
+      : "attenditop"
   );
   const [primaryColorLight, setPrimaryColorLight] = useState("#888");
   const [primaryColorDark, setPrimaryColorDark] = useState("#888");
@@ -62,11 +240,26 @@ const App = () => {
   const [appName, setAppName] = useState("");
   const { getPublicSetting } = useSettings();
 
+  const availableThemeVariants = Object.keys(THEME_VARIANT_TOKENS);
+
+  const activeTokens =
+    THEME_VARIANT_TOKENS[themeVariant]?.[mode] || ATTENDITOP_LIGHT;
+
   const colorMode = useMemo(
     () => ({
       toggleColorMode: () => {
         setMode(prevMode => (prevMode === "light" ? "dark" : "light"));
       },
+      setThemeVariant: variant => {
+        if (THEME_VARIANT_TOKENS[variant]) {
+          setThemeVariant(variant);
+        }
+      },
+      themeVariant,
+      availableThemeVariants: availableThemeVariants.map(variant => ({
+        value: variant,
+        label: THEME_VARIANT_LABELS[variant] || variant
+      })),
       setPrimaryColorLight: color => {
         setPrimaryColorLight(color);
       },
@@ -86,7 +279,7 @@ const App = () => {
         setAppName(name);
       }
     }),
-    []
+    [themeVariant]
   );
 
   const calculatedLogoDark = () => {
@@ -102,10 +295,26 @@ const App = () => {
     return appLogoLight;
   };
 
+  const bodyBackgroundImage =
+    mode !== "light"
+      ? "none"
+      : themeVariant === "attenditop"
+        ? "radial-gradient(900px at 10% 10%, rgba(255,122,0,0.08), transparent 60%), radial-gradient(1000px at 90% 90%, rgba(255,122,0,0.05), transparent 60%)"
+        : themeVariant === "ocean"
+          ? "radial-gradient(900px at 8% 8%, rgba(2,132,199,0.12), transparent 62%), radial-gradient(1200px at 94% 92%, rgba(56,189,248,0.08), transparent 66%)"
+          : "none";
+
+  const typographyFamily =
+    themeVariant === "legacy"
+      ? "'Roboto', 'Segoe UI', sans-serif"
+      : "'Geist', 'Segoe UI', sans-serif";
+
   const theme = useMemo(
     () =>
       createTheme(
         {
+          attenditop: activeTokens,
+          themeVariant,
           scrollbarStyles: {
             "&::-webkit-scrollbar": {
               width: "8px",
@@ -130,49 +339,87 @@ const App = () => {
             primary: {
               main: mode === "light" ? primaryColorLight : primaryColorDark
             },
+            secondary: {
+              main: activeTokens.primaryFallback
+            },
             textPrimary:
               mode === "light" ? primaryColorLight : primaryColorDark,
-            textCommon: mode === "light" ? "#000" : "#fff",
+            textCommon: activeTokens.text,
             borderPrimary:
               mode === "light" ? primaryColorLight : primaryColorDark,
             background: {
-              default: mode === "light" ? "#fafafa" : "#303030",
-              paper: mode === "light" ? "#fff" : "#424242"
+              default: activeTokens.bg,
+              paper: activeTokens.surface1
             },
             backgroundContrast: {
-              default: mode === "light" ? "#ddd" : "#888",
-              paper: mode === "light" ? "#ddd" : "#888",
-              border: mode === "light" ? "#aaa" : "#444"
+              default: activeTokens.surface3,
+              paper: activeTokens.surface2,
+              border: activeTokens.border
             },
             dark: { main: mode === "light" ? "#333333" : "#666" },
-            light: { main: mode === "light" ? "#F3F3F3" : "#333333" },
-            chatBubbleFromMe: {
-              main: mode === "light" ? "#dcf8c6" : "#005c4b"
+            light: {
+              main: activeTokens.surface2
             },
-            chatBubbleReceived: { main: mode === "light" ? "#fff" : "#024481" },
-            chatBackground: { main: mode === "light" ? "#f3f3f3" : "#333" },
-            tabHeaderBackground: mode === "light" ? "#EEE" : "#666",
-            optionsBackground: mode === "light" ? "#fafafa" : "#333",
-            options: mode === "light" ? "#fafafa" : "#666",
+            chatBubbleFromMe: {
+              main: activeTokens.chatFromMe
+            },
+            chatBubbleReceived: {
+              main: activeTokens.chatReceived
+            },
+            chatBackground: {
+              main: activeTokens.chatBackground
+            },
+            tabHeaderBackground: activeTokens.surface2,
+            optionsBackground: activeTokens.surface1,
+            options: activeTokens.surface2,
             fontecor: mode === "light" ? primaryColorLight : primaryColorDark,
-            fancyBackground: mode === "light" ? "#fafafa" : "#333",
-            bordabox: mode === "light" ? "#eee" : "#333",
-            newmessagebox: mode === "light" ? "#eee" : "#333",
-            inputdigita: mode === "light" ? "#fff" : "#666",
-            contactdrawer: mode === "light" ? "#fff" : "#666",
-            announcements: mode === "light" ? "#ededed" : "#333",
-            login: mode === "light" ? "#fff" : "#1C1C1C",
-            announcementspopover: mode === "light" ? "#fff" : "#666",
-            chatlist: { main: mode === "light" ? "#dfdfdf" : "#555" },
-            boxlist: mode === "light" ? "#ededed" : "#666",
-            boxchatlist: mode === "light" ? "#ededed" : "#333",
-            total: mode === "light" ? "#fff" : "#222",
-            messageIcons: mode === "light" ? "grey" : "#F3F3F3",
-            inputBackground: mode === "light" ? "#FFFFFF" : "#333",
+            fancyBackground: activeTokens.bg,
+            bordabox: activeTokens.border,
+            newmessagebox: activeTokens.surface2,
+            inputdigita: activeTokens.surface1,
+            contactdrawer: activeTokens.surface1,
+            announcements: activeTokens.surface2,
+            login: activeTokens.surface1,
+            announcementspopover: activeTokens.surface1,
+            chatlist: {
+              main: activeTokens.surface3
+            },
+            boxlist: activeTokens.surface2,
+            boxchatlist: activeTokens.surface2,
+            total: activeTokens.surface1,
+            messageIcons: mode === "light" ? activeTokens.textFaint : activeTokens.textMuted,
+            inputBackground: activeTokens.surface1,
             barraSuperior: mode === "light" ? primaryColorLight : "#666",
-            boxticket: mode === "light" ? "#EEE" : "#666",
-            campaigntab: mode === "light" ? "#ededed" : "#666",
+            boxticket: activeTokens.surface2,
+            campaigntab: activeTokens.surface2,
             ticketzproad: { main: "#39ACE7", contrastText: "white" }
+          },
+          shape: {
+            borderRadius: 10
+          },
+          typography: {
+            fontFamily: typographyFamily,
+            h1: { fontWeight: 600, letterSpacing: "-0.03em" },
+            h2: { fontWeight: 600, letterSpacing: "-0.02em" },
+            h3: { fontWeight: 600, letterSpacing: "-0.02em" },
+            h4: { fontWeight: 600, letterSpacing: "-0.02em" },
+            h5: { fontWeight: 600, letterSpacing: "-0.015em" },
+            h6: { fontWeight: 600, letterSpacing: "-0.01em" },
+            button: { fontWeight: 600, textTransform: "none" }
+          },
+          overrides: {
+            MuiCssBaseline: {
+              "@global": {
+                "html, body": {
+                  backgroundColor: activeTokens.bgAmbient,
+                  color: activeTokens.text,
+                  fontFeatureSettings: "'cv11','ss01','ss03'"
+                },
+                body: {
+                  backgroundImage: bodyBackgroundImage
+                }
+              }
+            }
           },
           mode,
           appLogoLight,
@@ -197,6 +444,7 @@ const App = () => {
       appName,
       locale,
       mode,
+      themeVariant,
       primaryColorDark,
       primaryColorLight
     ]
@@ -219,6 +467,10 @@ const App = () => {
   useEffect(() => {
     window.localStorage.setItem("preferredTheme", mode);
   }, [mode]);
+
+  useEffect(() => {
+    window.localStorage.setItem("preferredThemeVariant", themeVariant);
+  }, [themeVariant]);
 
   useEffect(() => {
     getPublicSetting("primaryColorLight")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -224,11 +224,15 @@ const App = () => {
   const preferredThemeVariant = window.localStorage.getItem(
     "preferredThemeVariant"
   );
+  const userCompanyId = Number(window.localStorage.getItem("companyId") || 0);
+  const canUseThemeVariantSelection = userCompanyId === 1;
   const [mode, setMode] = useState(
     preferredTheme ? preferredTheme : prefersDarkMode ? "dark" : "light"
   );
   const [themeVariant, setThemeVariant] = useState(
-    preferredThemeVariant && THEME_VARIANT_TOKENS[preferredThemeVariant]
+    canUseThemeVariantSelection &&
+      preferredThemeVariant &&
+      THEME_VARIANT_TOKENS[preferredThemeVariant]
       ? preferredThemeVariant
       : "attenditop"
   );
@@ -240,7 +244,9 @@ const App = () => {
   const [appName, setAppName] = useState("");
   const { getPublicSetting } = useSettings();
 
-  const availableThemeVariants = Object.keys(THEME_VARIANT_TOKENS);
+  const availableThemeVariants = canUseThemeVariantSelection
+    ? Object.keys(THEME_VARIANT_TOKENS)
+    : ["attenditop"];
 
   const activeTokens =
     THEME_VARIANT_TOKENS[themeVariant]?.[mode] || ATTENDITOP_LIGHT;
@@ -251,7 +257,7 @@ const App = () => {
         setMode(prevMode => (prevMode === "light" ? "dark" : "light"));
       },
       setThemeVariant: variant => {
-        if (THEME_VARIANT_TOKENS[variant]) {
+        if (canUseThemeVariantSelection && THEME_VARIANT_TOKENS[variant]) {
           setThemeVariant(variant);
         }
       },
@@ -279,7 +285,7 @@ const App = () => {
         setAppName(name);
       }
     }),
-    [themeVariant]
+    [canUseThemeVariantSelection, themeVariant]
   );
 
   const calculatedLogoDark = () => {
@@ -467,6 +473,13 @@ const App = () => {
   useEffect(() => {
     window.localStorage.setItem("preferredTheme", mode);
   }, [mode]);
+
+  useEffect(() => {
+    if (!canUseThemeVariantSelection && themeVariant !== "attenditop") {
+      setThemeVariant("attenditop");
+      window.localStorage.setItem("preferredThemeVariant", "attenditop");
+    }
+  }, [canUseThemeVariantSelection, themeVariant]);
 
   useEffect(() => {
     window.localStorage.setItem("preferredThemeVariant", themeVariant);

--- a/frontend/src/layout/index.js
+++ b/frontend/src/layout/index.js
@@ -552,6 +552,11 @@ const LoggedInLayout = ({ children, themeToggle }) => {
   };
 
   const userCompanyId = Number(user?.companyId ?? user?.company?.id ?? 0);
+  const currentUserCompanyId = Number(
+    currentUser?.companyId ?? currentUser?.company?.id ?? userCompanyId
+  );
+  const canSelectThemeVariant =
+    Boolean(currentUser?.super) && currentUserCompanyId === 1;
   const shouldShowCompanyDueDate =
     user?.profile === "admin" && userCompanyId !== 1;
   const companyDueDateText = user?.company?.dueDate
@@ -734,23 +739,27 @@ const LoggedInLayout = ({ children, themeToggle }) => {
                   </MenuItem>
                 ))}
               </NestedMenuItem>
-              <NestedMenuItem label="Tema visual" parentMenuOpen={menuOpen}>
-                {availableThemeVariants.map(variant => (
-                  <MenuItem
-                    key={variant.value}
-                    onClick={() => handleChooseThemeVariant(variant.value)}
-                  >
-                    <div
-                      style={{
-                        fontWeight:
-                          currentThemeVariant === variant.value ? "bold" : "normal"
-                      }}
+              {canSelectThemeVariant && (
+                <NestedMenuItem label="Tema visual" parentMenuOpen={menuOpen}>
+                  {availableThemeVariants.map(variant => (
+                    <MenuItem
+                      key={variant.value}
+                      onClick={() => handleChooseThemeVariant(variant.value)}
                     >
-                      {variant.label}
-                    </div>
-                  </MenuItem>
-                ))}
-              </NestedMenuItem>
+                      <div
+                        style={{
+                          fontWeight:
+                            currentThemeVariant === variant.value
+                              ? "bold"
+                              : "normal"
+                        }}
+                      >
+                        {variant.label}
+                      </div>
+                    </MenuItem>
+                  ))}
+                </NestedMenuItem>
+              )}
               <MenuItem onClick={handleOpenAboutModal}>
                 {i18n.t("about.aboutthe")}{" "}
                 {currentUser?.super ? "ticketz" : theme.appName}

--- a/frontend/src/layout/index.js
+++ b/frontend/src/layout/index.js
@@ -68,6 +68,10 @@ const useStyles = makeStyles(theme => ({
     display: "flex",
     height: "var(--vh)",
     backgroundColor: theme.palette.fancyBackground,
+    backgroundImage:
+      theme.mode === "light"
+        ? "radial-gradient(900px at 10% 10%, rgba(255,122,0,0.08), transparent 60%), radial-gradient(1000px at 90% 90%, rgba(255,122,0,0.04), transparent 60%)"
+        : "none",
     "& .MuiButton-outlinedPrimary": {
       color: theme.palette.primary,
       border:
@@ -100,10 +104,14 @@ const useStyles = makeStyles(theme => ({
     borderRadius: 20,
     overflow: "hidden",
     cursor: "pointer",
-    backgroundColor:
+    border: `1px solid ${
+      theme.mode === "light" ? "rgba(255,255,255,0.28)" : "rgba(255,255,255,0.2)"
+    }`,
+    background:
       theme.mode === "dark"
-        ? "rgba(0, 0, 0, 0.2)"
-        : "rgba(255, 255, 255, 0.15)",
+        ? "rgba(18,18,22,0.5)"
+        : "rgba(255, 255, 255, 0.20)",
+    backdropFilter: "blur(8px)",
     [theme.breakpoints.down("xs")]: {
       borderRadius: 20
     }
@@ -163,7 +171,11 @@ const useStyles = makeStyles(theme => ({
     background:
       localStorage.getItem("impersonated") === "true"
         ? theme.palette.secondary.main
-        : theme.palette.primary.main
+        : `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.secondary.main})`,
+    boxShadow:
+      theme.mode === "light"
+        ? "0 4px 20px -10px rgba(0,0,0,0.35)"
+        : "0 6px 24px -12px rgba(0,0,0,0.55)"
   },
   toolbarIcon: {
     display: "flex",
@@ -173,6 +185,10 @@ const useStyles = makeStyles(theme => ({
   },
   appBar: {
     zIndex: theme.zIndex.drawer + 1,
+    boxShadow: "none",
+    borderBottom: `1px solid ${
+      theme.mode === "light" ? "rgba(255,255,255,0.22)" : "rgba(255,255,255,0.06)"
+    }`,
     transition: theme.transitions.create(["width", "margin"], {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen
@@ -194,7 +210,15 @@ const useStyles = makeStyles(theme => ({
     }
   },
   menuButton: {
-    marginRight: 36
+    marginRight: 18,
+    borderRadius: 10,
+    color: theme.palette.primary.contrastText,
+    backgroundColor:
+      theme.mode === "light" ? "rgba(255,255,255,0.16)" : "rgba(0,0,0,0.22)",
+    "&:hover": {
+      backgroundColor:
+        theme.mode === "light" ? "rgba(255,255,255,0.24)" : "rgba(0,0,0,0.35)"
+    }
   },
   menuButtonHidden: {
     display: "none"
@@ -202,7 +226,9 @@ const useStyles = makeStyles(theme => ({
   title: {
     flexGrow: 1,
     fontSize: 14,
-    color: "white"
+    color: "white",
+    fontWeight: 600,
+    letterSpacing: "-0.01em"
   },
   userMenuInfoContainer: {
     padding: theme.spacing(1.5, 2),
@@ -216,6 +242,10 @@ const useStyles = makeStyles(theme => ({
     position: "relative",
     whiteSpace: "nowrap",
     width: drawerWidth,
+    borderRight: `1px solid ${
+      theme.mode === "light" ? "rgba(0,0,0,0.08)" : "rgba(255,255,255,0.12)"
+    }`,
+    backgroundColor: theme.palette.background.paper,
     transition: theme.transitions.create("width", {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen
@@ -226,6 +256,7 @@ const useStyles = makeStyles(theme => ({
   drawerPaperClose: {
     overflowX: "hidden",
     overflowY: "clip",
+    backgroundColor: theme.palette.background.paper,
     transition: theme.transitions.create("width", {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen
@@ -240,7 +271,8 @@ const useStyles = makeStyles(theme => ({
   },
   content: {
     flex: 1,
-    overflow: "auto"
+    overflow: "auto",
+    backgroundColor: "transparent"
   },
   container: {
     paddingTop: theme.spacing(4),
@@ -307,6 +339,8 @@ const LoggedInLayout = ({ children, themeToggle }) => {
   const greaterThenSm = useMediaQuery(theme.breakpoints.up("sm"));
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const { colorMode } = useContext(ColorModeContext);
+  const currentThemeVariant = colorMode.themeVariant || "attenditop";
+  const availableThemeVariants = colorMode.availableThemeVariants || [];
 
   const [currentLanguage, setCurrentLanguage] = useState(i18n.language);
 
@@ -508,6 +542,10 @@ const LoggedInLayout = ({ children, themeToggle }) => {
     colorMode.toggleColorMode();
   };
 
+  const handleChooseThemeVariant = variant => {
+    colorMode.setThemeVariant(variant);
+  };
+
   const handleChooseLanguage = language => {
     localStorage.setItem("language", language);
     window.location.reload(false);
@@ -692,6 +730,23 @@ const LoggedInLayout = ({ children, themeToggle }) => {
                       }}
                     >
                       {messages[m].translations.mainDrawer.appBar.i18n.language}
+                    </div>
+                  </MenuItem>
+                ))}
+              </NestedMenuItem>
+              <NestedMenuItem label="Tema visual" parentMenuOpen={menuOpen}>
+                {availableThemeVariants.map(variant => (
+                  <MenuItem
+                    key={variant.value}
+                    onClick={() => handleChooseThemeVariant(variant.value)}
+                  >
+                    <div
+                      style={{
+                        fontWeight:
+                          currentThemeVariant === variant.value ? "bold" : "normal"
+                      }}
+                    >
+                      {variant.label}
                     </div>
                   </MenuItem>
                 ))}

--- a/frontend/src/layout/themeContext.js
+++ b/frontend/src/layout/themeContext.js
@@ -2,6 +2,9 @@ import React from "react";
 
 const ColorModeContext = React.createContext({
   toggleColorMode: () => {},
+  setThemeVariant: _ => {},
+  themeVariant: "attenditop",
+  availableThemeVariants: [],
   setPrimaryColorLight: _ => {},
   setPrimaryColorDark: _ => {},
   setAppLogoLight: _ => {},


### PR DESCRIPTION
## Objetivo
Adicionar infraestrutura para seleção de variantes de tema em runtime no frontend, com persistência da escolha do usuário.

## Onde Foi Alterado E O Que Foi Feito
- frontend/src/App.js
  - Criação dos tokens de variantes de tema e mapeamento das opções disponíveis.
  - Inclusão do estado themeVariant com persistência (preferredThemeVariant).
  - Integração da variante selecionada na construção do tema ativo.
  - Fallback de segurança: fora da empresa 1, força variante padrão e ignora seleção de variantes.
- frontend/src/layout/themeContext.js
  - Extensão do contexto para expor themeVariant, setThemeVariant e availableThemeVariants.
- frontend/src/layout/index.js
  - Inclusão da UI de seleção de tema no layout (menu de tema visual).
  - Integração da troca de variante com o contexto global.
  - Restrição de acesso: seleção de tema disponível apenas para superusuário da empresa 1.

## Resultado
- Usuário autorizado pode alternar entre variantes visuais sem reiniciar a aplicação.
- Preferência de variante permanece salva entre sessões.
- Usuários fora da regra (não superusuário ou empresa diferente de 1) não visualizam o seletor.
- Mesmo com alteração manual no localStorage, fora da empresa 1 a variante volta para o padrão.

## Escopo
- Apenas frontend.
- Sem alterações de backend, API ou regras de negócio.