### PR TITLE
feat(contacts): allow enlarging contact profile photos

### DIFF
--- a/frontend/src/components/ClickableContactAvatar/index.js
+++ b/frontend/src/components/ClickableContactAvatar/index.js
@@ -4,6 +4,7 @@ import Avatar from "@material-ui/core/Avatar";
 
 import { generateColor } from "../../helpers/colorGenerator";
 import { getInitials } from "../../helpers/getInitials";
+import { i18n } from "../../translate/i18n";
 import MediaGalleryLightbox from "../MediaGalleryLightbox";
 
 const hasPreviewablePhoto = profilePicUrl => {
@@ -36,6 +37,9 @@ const ClickableContactAvatar = ({ contact, avatarProps = {} }) => {
   const { style: avatarStyle, ...restAvatarProps } = avatarProps;
   const previewable = hasPreviewablePhoto(contact?.profilePicUrl);
   const slides = useMemo(() => buildSlides(contact), [contact]);
+  const contactLabel =
+    contact?.name || contact?.number || i18n.t("contactModal.form.profile");
+  const avatarLabel = `${i18n.t("contactModal.form.profile")}: ${contactLabel}`;
 
   const avatar = (
     <Avatar
@@ -47,7 +51,7 @@ const ClickableContactAvatar = ({ contact, avatarProps = {} }) => {
         ...avatarStyle
       }}
       src={contact?.profilePicUrl}
-      alt="contact_image"
+      alt={avatarLabel}
     >
       {getInitials(contact?.name)}
     </Avatar>
@@ -74,6 +78,8 @@ const ClickableContactAvatar = ({ contact, avatarProps = {} }) => {
       <span
         role="button"
         tabIndex={0}
+        aria-label={avatarLabel}
+        aria-haspopup="dialog"
         onClick={handleOpen}
         onKeyDown={handleKeyDown}
         style={{

--- a/frontend/src/components/ClickableContactAvatar/index.js
+++ b/frontend/src/components/ClickableContactAvatar/index.js
@@ -1,0 +1,97 @@
+import React, { useMemo, useState } from "react";
+
+import Avatar from "@material-ui/core/Avatar";
+
+import { generateColor } from "../../helpers/colorGenerator";
+import { getInitials } from "../../helpers/getInitials";
+import MediaGalleryLightbox from "../MediaGalleryLightbox";
+
+const hasPreviewablePhoto = profilePicUrl => {
+  return Boolean(profilePicUrl && !profilePicUrl.includes("nopicture"));
+};
+
+const buildSlides = contact => {
+  if (!contact?.profilePicUrl) {
+    return [];
+  }
+
+  const identifier = contact?.id || contact?.number || contact?.name || "photo";
+
+  return [
+    {
+      key: `contact-${identifier}`,
+      src: contact.profilePicUrl,
+      thumbnail: contact.profilePicUrl,
+      description: contact?.name || undefined,
+      download: {
+        url: contact.profilePicUrl,
+        filename: `contact-${identifier}`
+      }
+    }
+  ];
+};
+
+const ClickableContactAvatar = ({ contact, avatarProps = {} }) => {
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+  const { style: avatarStyle, ...restAvatarProps } = avatarProps;
+  const previewable = hasPreviewablePhoto(contact?.profilePicUrl);
+  const slides = useMemo(() => buildSlides(contact), [contact]);
+
+  const avatar = (
+    <Avatar
+      {...restAvatarProps}
+      style={{
+        backgroundColor: generateColor(contact?.number),
+        color: "white",
+        fontWeight: "bold",
+        ...avatarStyle
+      }}
+      src={contact?.profilePicUrl}
+      alt="contact_image"
+    >
+      {getInitials(contact?.name)}
+    </Avatar>
+  );
+
+  if (!previewable) {
+    return avatar;
+  }
+
+  const handleOpen = event => {
+    event.preventDefault();
+    event.stopPropagation();
+    setLightboxOpen(true);
+  };
+
+  const handleKeyDown = event => {
+    if (event.key === "Enter" || event.key === " ") {
+      handleOpen(event);
+    }
+  };
+
+  return (
+    <>
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={handleOpen}
+        onKeyDown={handleKeyDown}
+        style={{
+          display: "inline-flex",
+          cursor: "zoom-in",
+          borderRadius: "50%"
+        }}
+      >
+        {avatar}
+      </span>
+      <MediaGalleryLightbox
+        open={lightboxOpen}
+        index={0}
+        slides={slides}
+        onClose={() => setLightboxOpen(false)}
+      />
+    </>
+  );
+};
+
+export default ClickableContactAvatar;

--- a/frontend/src/components/ContactDrawer/index.js
+++ b/frontend/src/components/ContactDrawer/index.js
@@ -6,8 +6,6 @@ import IconButton from "@material-ui/core/IconButton";
 import CloseIcon from "@material-ui/icons/Close";
 import Drawer from "@material-ui/core/Drawer";
 import Link from "@material-ui/core/Link";
-import InputLabel from "@material-ui/core/InputLabel";
-import Avatar from "@material-ui/core/Avatar";
 import Button from "@material-ui/core/Button";
 import Paper from "@material-ui/core/Paper";
 
@@ -18,10 +16,9 @@ import WhatsMarked from "react-whatsmarked";
 import { CardHeader } from "@material-ui/core";
 import ContactModal from "../ContactModal";
 import { TicketNotes } from "../TicketNotes";
-import { generateColor } from "../../helpers/colorGenerator";
-import { getInitials } from "../../helpers/getInitials";
 import { TagsContainer } from "../TagsContainer";
 import useSettings from "../../hooks/useSettings";
+import ClickableContactAvatar from "../ClickableContactAvatar";
 
 const drawerWidth = 320;
 
@@ -117,7 +114,7 @@ const ContactDrawer = ({
     });
 
     setOpenForm(false);
-  }, [open, contact]);
+  }, [contact, getSetting, open]);
 
   return (
     <>
@@ -150,24 +147,19 @@ const ContactDrawer = ({
           <div className={classes.content}>
             <div className={classes.contactHeader}>
               <CardHeader
-                onClick={() => {}}
-                style={{ cursor: "pointer", width: "100%", padding: 0 }}
+                style={{ width: "100%", padding: 0 }}
                 titleTypographyProps={{ noWrap: true }}
                 subheaderTypographyProps={{ noWrap: true }}
                 avatar={
-                  <Avatar
-                    src={contact.profilePicUrl}
-                    alt="contact_image"
-                    style={{
-                      width: 60,
-                      height: 60,
-                      backgroundColor: generateColor(contact?.number),
-                      color: "white",
-                      fontWeight: "bold"
+                  <ClickableContactAvatar
+                    contact={contact}
+                    avatarProps={{
+                      style: {
+                        width: 60,
+                        height: 60
+                      }
                     }}
-                  >
-                    {getInitials(contact?.name)}
-                  </Avatar>
+                  />
                 }
                 title={
                   <>

--- a/frontend/src/components/TicketInfo/index.js
+++ b/frontend/src/components/TicketInfo/index.js
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from "react";
 
-import { Avatar, CardHeader } from "@material-ui/core";
+import { CardHeader } from "@material-ui/core";
 
 import { i18n } from "../../translate/i18n";
-import { getInitials } from "../../helpers/getInitials";
-import { generateColor } from "../../helpers/colorGenerator";
+import ClickableContactAvatar from "../ClickableContactAvatar";
 
 const TicketInfo = ({ contact, ticket, onClick }) => {
   const { user } = ticket;
@@ -38,19 +37,7 @@ const TicketInfo = ({ contact, ticket, onClick }) => {
       style={{ cursor: "pointer" }}
       titleTypographyProps={{ noWrap: true }}
       subheaderTypographyProps={{ noWrap: true }}
-      avatar={
-        <Avatar
-          style={{
-            backgroundColor: generateColor(contact?.number),
-            color: "white",
-            fontWeight: "bold"
-          }}
-          src={contact.profilePicUrl}
-          alt="contact_image"
-        >
-          {getInitials(contact?.name)}
-        </Avatar>
-      }
+      avatar={<ClickableContactAvatar contact={contact} />}
       title={`${contactName} #${ticket.id}`}
       subheader={ticket.user && `${userName}`}
     />


### PR DESCRIPTION
## Objetivo

Implementar o escopo original da issue #417: permitir ampliar a foto de perfil do contato diretamente durante o atendimento, sem introduzir dependências novas nem alterar backend/API.

## O que foi alterado

### Frontend

- criação do componente reutilizável `ClickableContactAvatar`, responsável por encapsular avatar clicável, acessibilidade por teclado e abertura do lightbox
- integração desse componente no drawer de detalhes do contato
- integração desse componente no cabeçalho do ticket
- reaproveitamento do `MediaGalleryLightbox`, mantendo a solução alinhada ao padrão já existente no projeto
- preservação do fallback com iniciais quando o contato não possui foto utilizável

## Resultado funcional

- o atendente consegue ampliar a foto do cliente sem sair do fluxo do ticket
- o comportamento fica disponível nos dois pontos mais relevantes da conversa: cabeçalho do ticket e drawer do contato
- a mudança é inteiramente frontend e não altera contratos existentes

## Validação executada

- `npx eslint src/components/ClickableContactAvatar/index.js src/components/ContactDrawer/index.js src/components/TicketInfo/index.js`

## Relação com outras PRs

- esta PR entrega a base reutilizável usada pela PR complementar #487
- a #487 expande a experiência de contatos, mas depende desta fundação para evitar duplicação de implementação

## Issue

- Relacionada: https://github.com/ticketz-oss/ticketz/issues/417
- Closes #417