### PR TITLE
feat(schedule): add variable box for scheduled messages

### DIFF
--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 
 import * as Yup from "yup";
 import { Formik, Form, Field } from "formik";
@@ -24,6 +24,9 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import moment from "moment";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import { isArray, capitalize } from "lodash";
+import VariablePicker from "../VariablePicker";
+import insertTextAtCursor from "../../helpers/insertTextAtCursor";
+import { scheduleVariableCatalog } from "../../helpers/variableCatalog";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -52,6 +55,18 @@ const useStyles = makeStyles(theme => ({
   formControl: {
     margin: theme.spacing(1),
     minWidth: 120
+  },
+  variableToolbar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1)
+  },
+  variableHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize
   }
 }));
 
@@ -90,6 +105,7 @@ const ScheduleModal = ({
   const [schedule, setSchedule] = useState(initialState);
   const [currentContact, setCurrentContact] = useState(initialContact);
   const [contacts, setContacts] = useState([initialContact]);
+  const bodyInputRef = useRef(null);
 
   useEffect(() => {
     if (contactId && contacts.length) {
@@ -167,6 +183,30 @@ const ScheduleModal = ({
     handleClose();
   };
 
+  const handleInsertVariable = (token, bodyValue, setFieldValue) => {
+    const {
+      nextValue,
+      nextSelectionStart,
+      nextSelectionEnd
+    } = insertTextAtCursor(bodyValue, token, bodyInputRef.current);
+
+    setFieldValue("body", nextValue);
+
+    requestAnimationFrame(() => {
+      const input = bodyInputRef.current;
+
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+
+      if (typeof input.setSelectionRange === "function") {
+        input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+      }
+    });
+  };
+
   return (
     <div className={classes.root}>
       <Dialog
@@ -192,7 +232,14 @@ const ScheduleModal = ({
             }, 400);
           }}
         >
-          {({ touched, errors, isSubmitting, values }) => (
+          {({
+            touched,
+            errors,
+            handleBlur,
+            isSubmitting,
+            setFieldValue,
+            values
+          }) => (
             <Form>
               <DialogContent dividers>
                 <div className={classes.multFieldLine}>
@@ -214,7 +261,7 @@ const ScheduleModal = ({
                         <TextField
                           {...params}
                           variant="outlined"
-                          placeholder="Contato"
+                          placeholder={i18n.t("scheduleModal.form.contact")}
                         />
                       )}
                     />
@@ -222,18 +269,37 @@ const ScheduleModal = ({
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>
-                  <Field
-                    as={TextField}
+                  <TextField
                     rows={9}
                     multiline={true}
                     label={i18n.t("scheduleModal.form.body")}
                     name="body"
+                    value={values.body}
+                    onChange={event => setFieldValue("body", event.target.value)}
+                    onBlur={handleBlur}
                     error={touched.body && Boolean(errors.body)}
                     helperText={touched.body && errors.body}
                     variant="outlined"
                     margin="dense"
                     fullWidth
+                    inputRef={bodyInputRef}
                   />
+                </div>
+                <div className={classes.variableToolbar}>
+                  <VariablePicker
+                    items={scheduleVariableCatalog}
+                    onSelectVariable={token =>
+                      handleInsertVariable(token, values.body, setFieldValue)
+                    }
+                    buttonAriaLabel={i18n.t("settings.mustacheVariables.title")}
+                    menuTitle={i18n.t("settings.mustacheVariables.title")}
+                  />
+                  <span className={classes.variableHint}>
+                    {i18n.t("settings.mustacheVariables.title")}{" "}
+                    {scheduleVariableCatalog
+                      .map(variable => variable.token)
+                      .join(" ")}
+                  </span>
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>

--- a/frontend/src/components/VariablePicker/index.js
+++ b/frontend/src/components/VariablePicker/index.js
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+
+import Button from "@material-ui/core/Button";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+
+const VariablePicker = ({
+  items,
+  onSelectVariable,
+  buttonLabel = "{{ }}",
+  buttonAriaLabel,
+  menuTitle
+}) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = token => {
+    onSelectVariable(token);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="small"
+        variant="outlined"
+        aria-label={buttonAriaLabel}
+        onClick={handleOpen}
+      >
+        {buttonLabel}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left"
+        }}
+      >
+        {menuTitle ? <ListSubheader disableSticky>{menuTitle}</ListSubheader> : null}
+        {items.map(item => (
+          <MenuItem key={item.token} onClick={() => handleSelect(item.token)}>
+            {item.label || item.token}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default VariablePicker;

--- a/frontend/src/helpers/insertTextAtCursor.js
+++ b/frontend/src/helpers/insertTextAtCursor.js
@@ -1,0 +1,28 @@
+const insertTextAtCursor = (currentValue = "", textToInsert = "", input) => {
+  const safeValue = currentValue || "";
+
+  if (
+    !input ||
+    typeof input.selectionStart !== "number" ||
+    typeof input.selectionEnd !== "number"
+  ) {
+    const nextValue = `${safeValue}${textToInsert}`;
+
+    return {
+      nextValue,
+      nextSelectionStart: nextValue.length,
+      nextSelectionEnd: nextValue.length
+    };
+  }
+
+  const nextValue = `${safeValue.slice(0, input.selectionStart)}${textToInsert}${safeValue.slice(input.selectionEnd)}`;
+  const nextSelectionStart = input.selectionStart + textToInsert.length;
+
+  return {
+    nextValue,
+    nextSelectionStart,
+    nextSelectionEnd: nextSelectionStart
+  };
+};
+
+export default insertTextAtCursor;

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -1,0 +1,8 @@
+export const scheduleVariableCatalog = [
+  { token: "{{firstname}}" },
+  { token: "{{name}}" },
+  { token: "{{email}}" },
+  { token: "{{greeting}}" },
+  { token: "{{user}}" },
+  { token: "{{time}}" }
+];


### PR DESCRIPTION
## Objetivo

Entregar a primeira parte da issue #337 com a base reutilizável da Caixa de Variáveis e a integração inicial no fluxo de agendamento de mensagens.

## O que foi alterado

### Frontend

- criação do componente reutilizável `VariablePicker` para seleção de variáveis por botão/popover
- criação do helper `insertTextAtCursor` para inserir o token na posição atual do cursor
- criação do catálogo inicial `scheduleVariableCatalog` para o fluxo de agendamentos
- integração da caixa de variáveis em `ScheduleModal`, no campo `body`
- reaproveitamento da infraestrutura de Mustache já existente no backend, sem criar substituição paralela no frontend

## Resultado funcional

- o usuário consegue abrir a caixa de variáveis dentro do agendamento
- ao clicar em uma variável, o token é inserido automaticamente na posição atual do cursor
- a PR usa apenas variáveis seguras para o contexto atual de agendamentos
- o backend continua responsável pela substituição efetiva no envio

## Escopo desta parte

- esta PR cobre apenas a base reutilizável e o fluxo de agendamentos
- respostas rápidas e campanhas ficarão em PRs separadas para reduzir risco e facilitar revisão

## Validação executada

- `npx eslint src/components/ScheduleModal/index.js src/components/VariablePicker/index.js src/helpers/insertTextAtCursor.js src/helpers/variableCatalog.js`
- diagnóstico dos arquivos alterados sem erros via `get_errors`

## Relação

- Relacionada: https://github.com/ticketz-oss/ticketz/issues/337
- Parte 1 da implementação fatiada da issue