### PR TITLE
feat(campaigns): add variable box to campaign messages

### DIFF
--- a/frontend/src/components/CampaignModal/index.js
+++ b/frontend/src/components/CampaignModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useContext } from "react";
+import React, { useState, useEffect, useMemo, useRef, useContext } from "react";
 
 import * as Yup from "yup";
 import { Formik, Form, Field } from "formik";
@@ -35,6 +35,27 @@ import {
 } from "@material-ui/core";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import ConfirmationModal from "../ConfirmationModal";
+import VariablePicker from "../VariablePicker";
+import insertTextAtCursor from "../../helpers/insertTextAtCursor";
+import { buildCampaignVariableCatalog } from "../../helpers/variableCatalog";
+
+const getCampaignSettingVariables = settings => {
+  const variablesSetting = Array.isArray(settings)
+    ? settings.find(setting => setting.key === "variables")
+    : null;
+
+  if (!variablesSetting?.value) {
+    return [];
+  }
+
+  try {
+    const parsedValue = JSON.parse(variablesSetting.value);
+
+    return Array.isArray(parsedValue) ? parsedValue : [];
+  } catch (error) {
+    return [];
+  }
+};
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -64,6 +85,18 @@ const useStyles = makeStyles(theme => ({
     left: "50%",
     marginTop: -12,
     marginLeft: -12
+  },
+  variableToolbar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1)
+  },
+  variableHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize
   }
 }));
 
@@ -114,7 +147,12 @@ const CampaignModal = ({
   const [attachment, setAttachment] = useState(null);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
   const [campaignEditable, setCampaignEditable] = useState(true);
+  const [campaignSettingsVariables, setCampaignSettingsVariables] = useState([]);
   const attachmentFile = useRef(null);
+  const messageInputRefs = useRef({});
+  const campaignVariableCatalog = useMemo(() => {
+    return buildCampaignVariableCatalog(campaignSettingsVariables);
+  }, [campaignSettingsVariables]);
 
   useEffect(() => {
     return () => {
@@ -137,6 +175,10 @@ const CampaignModal = ({
       api
         .get(`/whatsapp`, { params: { companyId, session: 0 } })
         .then(({ data }) => setWhatsapps(data));
+
+      api
+        .get("/campaign-settings")
+        .then(({ data }) => setCampaignSettingsVariables(getCampaignSettingVariables(data)));
 
       if (!campaignId) return;
 
@@ -235,40 +277,119 @@ const CampaignModal = ({
     }
   };
 
-  const renderMessageField = identifier => {
+  const handleInsertVariable = (identifier, token, fieldValue, setFieldValue) => {
+    const { nextValue, nextSelectionStart, nextSelectionEnd } =
+      insertTextAtCursor(fieldValue, token, messageInputRefs.current[identifier]);
+
+    setFieldValue(identifier, nextValue);
+
+    requestAnimationFrame(() => {
+      const input = messageInputRefs.current[identifier];
+
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+
+      if (typeof input.setSelectionRange === "function") {
+        input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+      }
+    });
+  };
+
+  const renderVariableToolbar = (identifier, values, setFieldValue) => {
     return (
-      <Field
-        as={TextField}
-        id={identifier}
-        name={identifier}
-        spellCheck={true}
-        fullWidth
-        rows={5}
-        label={i18n.t(`campaigns.dialog.form.${identifier}`)}
-        placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
-        multiline={true}
-        variant="outlined"
-        helperText="Utilize variáveis como {nome}, {numero}, {email} ou defina variáveis personalziadas."
-        disabled={!campaignEditable && campaign.status !== "CANCELADA"}
-      />
+      <div className={classes.variableToolbar}>
+        <VariablePicker
+          items={campaignVariableCatalog}
+          onSelectVariable={token =>
+            handleInsertVariable(
+              identifier,
+              token,
+              values[identifier],
+              setFieldValue
+            )
+          }
+          buttonLabel="{ }"
+          buttonAriaLabel={i18n.t("settings.mustacheVariables.title")}
+          menuTitle={i18n.t("settings.mustacheVariables.title")}
+        />
+        <span className={classes.variableHint}>
+          {i18n.t("settings.mustacheVariables.title")}{" "}
+          {campaignVariableCatalog.map(variable => variable.token).join(" ")}
+        </span>
+      </div>
     );
   };
 
-  const renderConfirmationMessageField = identifier => {
+  const renderMessageField = ({
+    identifier,
+    touched,
+    errors,
+    handleBlur,
+    setFieldValue,
+    values
+  }) => {
     return (
-      <Field
-        as={TextField}
-        id={identifier}
-        name={identifier}
-        spellCheck={true}
-        fullWidth
-        rows={5}
-        label={i18n.t(`campaigns.dialog.form.${identifier}`)}
-        placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
-        multiline={true}
-        variant="outlined"
-        disabled={!campaignEditable && campaign.status !== "CANCELADA"}
-      />
+      <>
+        <TextField
+          id={identifier}
+          name={identifier}
+          spellCheck={true}
+          fullWidth
+          rows={5}
+          label={i18n.t(`campaigns.dialog.form.${identifier}`)}
+          placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
+          multiline={true}
+          variant="outlined"
+          value={values[identifier] || ""}
+          onChange={event => setFieldValue(identifier, event.target.value)}
+          onBlur={handleBlur}
+          error={touched[identifier] && Boolean(errors[identifier])}
+          helperText={touched[identifier] && errors[identifier]}
+          disabled={!campaignEditable && campaign.status !== "CANCELADA"}
+          inputRef={input => {
+            messageInputRefs.current[identifier] = input;
+          }}
+        />
+        {renderVariableToolbar(identifier, values, setFieldValue)}
+      </>
+    );
+  };
+
+  const renderConfirmationMessageField = ({
+    identifier,
+    touched,
+    errors,
+    handleBlur,
+    setFieldValue,
+    values
+  }) => {
+    return (
+      <>
+        <TextField
+          id={identifier}
+          name={identifier}
+          spellCheck={true}
+          fullWidth
+          rows={5}
+          label={i18n.t(`campaigns.dialog.form.${identifier}`)}
+          placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
+          multiline={true}
+          variant="outlined"
+          value={values[identifier] || ""}
+          onChange={event => setFieldValue(identifier, event.target.value)}
+          onBlur={handleBlur}
+          error={touched[identifier] && Boolean(errors[identifier])}
+          helperText={touched[identifier] && errors[identifier]}
+          disabled={!campaignEditable && campaign.status !== "CANCELADA"}
+          inputRef={input => {
+            messageInputRefs.current[identifier] = input;
+          }}
+        />
+        {renderVariableToolbar(identifier, values, setFieldValue)}
+      </>
     );
   };
 
@@ -340,7 +461,14 @@ const CampaignModal = ({
             }, 400);
           }}
         >
-          {({ values, errors, touched, isSubmitting }) => (
+          {({
+            values,
+            errors,
+            touched,
+            handleBlur,
+            isSubmitting,
+            setFieldValue
+          }) => (
             <Form>
               <DialogContent dividers>
                 <Grid spacing={2} container>
@@ -493,18 +621,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message1")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message1",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage1"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage1",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message1")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message1",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -513,18 +664,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message2")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message2",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage2"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage2",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message2")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message2",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -533,18 +707,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message3")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message3",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage3"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage3",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message3")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message3",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -553,18 +750,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message4")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message4",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage4"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage4",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message4")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message4",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -573,18 +793,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message5")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message5",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage5"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage5",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message5")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message5",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}

--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 
 import * as Yup from "yup";
 import { Formik, Form, Field } from "formik";
@@ -24,6 +24,9 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import moment from "moment";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import { isArray, capitalize } from "lodash";
+import VariablePicker from "../VariablePicker";
+import insertTextAtCursor from "../../helpers/insertTextAtCursor";
+import { scheduleVariableCatalog } from "../../helpers/variableCatalog";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -52,6 +55,18 @@ const useStyles = makeStyles(theme => ({
   formControl: {
     margin: theme.spacing(1),
     minWidth: 120
+  },
+  variableToolbar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1)
+  },
+  variableHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize
   }
 }));
 
@@ -90,6 +105,7 @@ const ScheduleModal = ({
   const [schedule, setSchedule] = useState(initialState);
   const [currentContact, setCurrentContact] = useState(initialContact);
   const [contacts, setContacts] = useState([initialContact]);
+  const bodyInputRef = useRef(null);
 
   useEffect(() => {
     if (contactId && contacts.length) {
@@ -167,6 +183,30 @@ const ScheduleModal = ({
     handleClose();
   };
 
+  const handleInsertVariable = (token, bodyValue, setFieldValue) => {
+    const {
+      nextValue,
+      nextSelectionStart,
+      nextSelectionEnd
+    } = insertTextAtCursor(bodyValue, token, bodyInputRef.current);
+
+    setFieldValue("body", nextValue);
+
+    requestAnimationFrame(() => {
+      const input = bodyInputRef.current;
+
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+
+      if (typeof input.setSelectionRange === "function") {
+        input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+      }
+    });
+  };
+
   return (
     <div className={classes.root}>
       <Dialog
@@ -192,7 +232,14 @@ const ScheduleModal = ({
             }, 400);
           }}
         >
-          {({ touched, errors, isSubmitting, values }) => (
+          {({
+            touched,
+            errors,
+            handleBlur,
+            isSubmitting,
+            setFieldValue,
+            values
+          }) => (
             <Form>
               <DialogContent dividers>
                 <div className={classes.multFieldLine}>
@@ -214,7 +261,7 @@ const ScheduleModal = ({
                         <TextField
                           {...params}
                           variant="outlined"
-                          placeholder="Contato"
+                          placeholder={i18n.t("scheduleModal.form.contact")}
                         />
                       )}
                     />
@@ -222,18 +269,37 @@ const ScheduleModal = ({
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>
-                  <Field
-                    as={TextField}
+                  <TextField
                     rows={9}
                     multiline={true}
                     label={i18n.t("scheduleModal.form.body")}
                     name="body"
+                    value={values.body}
+                    onChange={event => setFieldValue("body", event.target.value)}
+                    onBlur={handleBlur}
                     error={touched.body && Boolean(errors.body)}
                     helperText={touched.body && errors.body}
                     variant="outlined"
                     margin="dense"
                     fullWidth
+                    inputRef={bodyInputRef}
                   />
+                </div>
+                <div className={classes.variableToolbar}>
+                  <VariablePicker
+                    items={scheduleVariableCatalog}
+                    onSelectVariable={token =>
+                      handleInsertVariable(token, values.body, setFieldValue)
+                    }
+                    buttonAriaLabel={i18n.t("settings.mustacheVariables.title")}
+                    menuTitle={i18n.t("settings.mustacheVariables.title")}
+                  />
+                  <span className={classes.variableHint}>
+                    {i18n.t("settings.mustacheVariables.title")}{" "}
+                    {scheduleVariableCatalog
+                      .map(variable => variable.token)
+                      .join(" ")}
+                  </span>
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>

--- a/frontend/src/components/VariablePicker/index.js
+++ b/frontend/src/components/VariablePicker/index.js
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+
+import Button from "@material-ui/core/Button";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+
+const VariablePicker = ({
+  items,
+  onSelectVariable,
+  buttonLabel = "{{ }}",
+  buttonAriaLabel,
+  menuTitle
+}) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = token => {
+    onSelectVariable(token);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="small"
+        variant="outlined"
+        aria-label={buttonAriaLabel}
+        onClick={handleOpen}
+      >
+        {buttonLabel}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left"
+        }}
+      >
+        {menuTitle ? <ListSubheader disableSticky>{menuTitle}</ListSubheader> : null}
+        {items.map(item => (
+          <MenuItem key={item.token} onClick={() => handleSelect(item.token)}>
+            {item.label || item.token}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default VariablePicker;

--- a/frontend/src/helpers/insertTextAtCursor.js
+++ b/frontend/src/helpers/insertTextAtCursor.js
@@ -1,0 +1,28 @@
+const insertTextAtCursor = (currentValue = "", textToInsert = "", input) => {
+  const safeValue = currentValue || "";
+
+  if (
+    !input ||
+    typeof input.selectionStart !== "number" ||
+    typeof input.selectionEnd !== "number"
+  ) {
+    const nextValue = `${safeValue}${textToInsert}`;
+
+    return {
+      nextValue,
+      nextSelectionStart: nextValue.length,
+      nextSelectionEnd: nextValue.length
+    };
+  }
+
+  const nextValue = `${safeValue.slice(0, input.selectionStart)}${textToInsert}${safeValue.slice(input.selectionEnd)}`;
+  const nextSelectionStart = input.selectionStart + textToInsert.length;
+
+  return {
+    nextValue,
+    nextSelectionStart,
+    nextSelectionEnd: nextSelectionStart
+  };
+};
+
+export default insertTextAtCursor;

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -1,0 +1,8 @@
+export const scheduleVariableCatalog = [
+  { token: "{{firstname}}" },
+  { token: "{{name}}" },
+  { token: "{{email}}" },
+  { token: "{{greeting}}" },
+  { token: "{{user}}" },
+  { token: "{{time}}" }
+];

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -6,3 +6,28 @@ export const scheduleVariableCatalog = [
   { token: "{{user}}" },
   { token: "{{time}}" }
 ];
+
+export const campaignNativeVariableCatalog = [
+  { token: "{nome}" },
+  { token: "{numero}" },
+  { token: "{email}" }
+];
+
+export const buildCampaignVariableCatalog = (variables = []) => {
+  const customVariables = variables
+    .filter(variable => variable?.key)
+    .map(variable => ({
+      token: `{${variable.key}}`
+    }));
+
+  const uniqueTokens = new Set();
+
+  return [...campaignNativeVariableCatalog, ...customVariables].filter(item => {
+    if (uniqueTokens.has(item.token)) {
+      return false;
+    }
+
+    uniqueTokens.add(item.token);
+    return true;
+  });
+};


### PR DESCRIPTION
## Objetivo

Entregar a terceira parte da issue #337 com a integração da Caixa de Variáveis no fluxo de campanhas, mantendo compatibilidade total com os placeholders já suportados hoje.

## O que foi alterado

### Frontend

- integração do `VariablePicker` em `CampaignModal` para campos de mensagem e mensagens de confirmação
- reaproveitamento do helper `insertTextAtCursor` para inserir tokens na posição atual do cursor
- expansão do catálogo compartilhado com variáveis nativas de campanhas e variáveis customizadas já cadastradas em `CampaignsConfig`
- carregamento das variáveis customizadas já existentes via `/campaign-settings`, sem alterar o backend de processamento nesta etapa

## Resultado funcional

- o usuário consegue inserir automaticamente variáveis em mensagens de campanha
- o mesmo comportamento fica disponível também para mensagens de confirmação
- a PR mantém o formato atual compatível com o backend: `{nome}`, `{numero}`, `{email}` e variáveis customizadas
- não há mudança de contrato nem nova sintaxe obrigatória nesta parte

## Escopo desta parte

- esta PR cobre apenas campanhas com compatibilidade atual
- ela depende da base reutilizável publicada na PR #488
- a expansão para novas categorias de variáveis em campanhas ficará para a próxima parte

## Observação de base

- esta branch foi construída sobre a fundação da PR #488, porque o picker reutilizável e os helpers compartilhados são pré-requisitos deste fluxo
- como a conta autenticada tem permissão READ no repositório oficial, não foi possível publicar uma branch-base diretamente em `ticketz-oss/ticketz`
- por isso, esta PR foi aberta contra `main` e ainda inclui a fundação da #488 no diff
- quando a #488 for mergeada, esta branch pode ser rebaseada para deixar o diff final isolado apenas no escopo desta PR

## Validação executada

- `npx eslint src/components/CampaignModal/index.js src/helpers/variableCatalog.js src/components/VariablePicker/index.js src/helpers/insertTextAtCursor.js`
- diagnóstico dos arquivos alterados sem erros via `get_errors`

## Relação

- Relacionada: https://github.com/ticketz-oss/ticketz/issues/337
- Dependência funcional: https://github.com/ticketz-oss/ticketz/pull/488
- Parte 3 da implementação fatiada da issue