### PR TITLE
feat(campaigns): expand campaign variable support

### DIFF
--- a/backend/src/controllers/ContactController.ts
+++ b/backend/src/controllers/ContactController.ts
@@ -10,6 +10,7 @@ import ShowContactService from "../services/ContactServices/ShowContactService";
 import UpdateContactService from "../services/ContactServices/UpdateContactService";
 import DeleteContactService from "../services/ContactServices/DeleteContactService";
 import GetContactService from "../services/ContactServices/GetContactService";
+import ListExtraFieldNamesService from "../services/ContactServices/ListExtraFieldNamesService";
 
 import CheckContactNumber, {
   CheckNumberAndCreateContact,
@@ -40,16 +41,22 @@ type IndexGetContactQuery = {
   number: string;
 };
 
-interface ExtraInfo extends ContactCustomField {
+type CreateContactPayload = Parameters<typeof CreateContactService>[0];
+
+type ExtraInfoPayload = {
+  id?: number;
   name: string;
   value: string;
-}
+};
+
 interface ContactData {
   name: string;
   number: string;
   email?: string;
   isGroup?: boolean;
-  extraInfo?: ExtraInfo[];
+  extraInfo?: ExtraInfoPayload[];
+  disableBot?: boolean;
+  language?: string;
 }
 
 export const index = async (req: Request, res: Response): Promise<Response> => {
@@ -95,8 +102,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
 
   try {
     await schema.validate(newContact);
-  } catch (err: any) {
-    throw new AppError(err.message);
+  } catch (err: unknown) {
+    throw new AppError(err instanceof Error ? err.message : String(err));
   }
 
   let contact: Contact;
@@ -110,7 +117,7 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     contact = await CreateContactService({
       ...newContact,
       companyId
-    });
+    } as CreateContactPayload);
   }
 
   const io = getIO();
@@ -134,6 +141,17 @@ export const show = async (req: Request, res: Response): Promise<Response> => {
   return res.status(200).json(contact);
 };
 
+export const listExtraFieldNames = async (
+  req: Request,
+  res: Response
+): Promise<Response> => {
+  const { companyId } = req.user;
+
+  const extraFieldNames = await ListExtraFieldNamesService(companyId);
+
+  return res.status(200).json(extraFieldNames);
+};
+
 export const update = async (
   req: Request,
   res: Response
@@ -148,8 +166,8 @@ export const update = async (
 
   try {
     await schema.validate(contactData);
-  } catch (err: any) {
-    throw new AppError(err.message);
+  } catch (err: unknown) {
+    throw new AppError(err instanceof Error ? err.message : String(err));
   }
 
   let checked: IOnWhatsapp;
@@ -280,64 +298,69 @@ export const importCsv = async (
   try {
     const firstLine = fs.readFileSync(file.path, "utf8").split("\n")[0];
     delimiter = firstLine.includes(";") ? ";" : ",";
-  } catch (error) {
+  } catch {
     throw new AppError("ERR_INVALID_CSV", 400);
   }
 
-  const parser = csvParser({ delimiter, columns: true }, async (err, data) => {
-    if (err) {
-      throw new AppError("ERR_INVALID_CSV", 400);
-    }
-
-    data.forEach(async (record: any) => {
-      let extraInfo: any[];
-      try {
-        extraInfo = JSON.parse(record.ExtraInfo);
-      } catch (error) {
-        extraInfo = [];
+  const parser = csvParser(
+    { delimiter, columns: true },
+    async (err, data: Record<string, string>[]) => {
+      if (err) {
+        throw new AppError("ERR_INVALID_CSV", 400);
       }
 
-      const contact = {
-        companyId,
-        name: record.name || record.Name,
-        number: record.number || record.Number,
-        email: record.email || record.Email,
-        extraInfo
-      };
+      data.forEach(async record => {
+        let extraInfo: ExtraInfoPayload[];
+        try {
+          extraInfo = JSON.parse(record.ExtraInfo || "[]");
+        } catch {
+          extraInfo = [];
+        }
 
-      Object.keys(record).forEach((key: string) => {
-        if (
-          key !== "name" &&
-          key !== "number" &&
-          key !== "email" &&
-          key !== "Name" &&
-          key !== "Number" &&
-          key !== "Email" &&
-          key !== "ExtraInfo" &&
-          record[key]
-        ) {
-          contact.extraInfo.push({
-            name: key,
-            value: record[key]
-          });
+        const contact = {
+          companyId,
+          name: record.name || record.Name,
+          number: record.number || record.Number,
+          email: record.email || record.Email,
+          extraInfo
+        };
+
+        Object.keys(record).forEach((key: string) => {
+          if (
+            key !== "name" &&
+            key !== "number" &&
+            key !== "email" &&
+            key !== "Name" &&
+            key !== "Number" &&
+            key !== "Email" &&
+            key !== "ExtraInfo" &&
+            record[key]
+          ) {
+            contact.extraInfo.push({
+              name: key,
+              value: record[key]
+            });
+          }
+        });
+
+        try {
+          const newContact = await CreateContactService(
+            contact as CreateContactPayload
+          );
+          const io = getIO();
+          io.to(`company-${companyId}-mainchannel`).emit(
+            `company-${companyId}-contact`,
+            {
+              action: "update",
+              contact: newContact
+            }
+          );
+        } catch (error) {
+          logger.error({ contact }, `Error creating contact: ${error.message}`);
         }
       });
-
-      try {
-        const newContact = await CreateContactService(contact);
-        const io = getIO();
-        io.to(`company-${companyId}-mainchannel`).emit(
-          `company-${companyId}-contact`,
-          {
-            action: "update",
-            contact: newContact
-          }
-        );
-      } catch (error) {
-        logger.error({ contact }, `Error creating contact: ${error.message}`);
-      }
-    });
-  });
+    }
+  );
 
   const readable = fs.createReadStream(file.path);
 
@@ -371,8 +394,8 @@ export const exportCsv = async (
     ]
   });
 
-  const records = contacts.map((contact: any) => {
-    const extraInfo = contact.extraInfo.map((info: any) => ({
+  const records = contacts.map(contact => {
+    const extraInfo = contact.extraInfo.map(info => ({
       name: info.name,
       value: info.value
     }));

--- a/backend/src/helpers/Mustache.ts
+++ b/backend/src/helpers/Mustache.ts
@@ -24,15 +24,14 @@ export const genGreeting = (
     _t("Good evening", lngSource)
   ];
   const h = new Date().getHours();
-  // eslint-disable-next-line no-bitwise
   return greetings[(h / 6) >> 0];
 };
 
 export function mustacheValues(
-  ticket: Ticket,
-  contact: Contact | ContactListItem,
-  currentUser: User
-): Record<string, any> {
+  ticket?: Ticket,
+  contact?: Contact | ContactListItem,
+  currentUser?: User
+): Record<string, unknown> {
   contact = contact || ticket?.contact;
 
   const name = contact?.name || contact?.number || "{{name}}";
@@ -53,15 +52,18 @@ export function mustacheValues(
     "{{protocol}}";
   const time = now.toLocaleTimeString("en-GB", { hour12: false });
 
-  let extraInfo: any;
+  let extraInfo: Record<string, string> = {};
 
   if (contact instanceof ContactListItem) {
-    extraInfo = {}; // contact.extraInfo;
+    extraInfo = {};
   } else if (contact && contact.extraInfo) {
-    extraInfo = contact.extraInfo.reduce((acc, field) => {
-      acc[field.name] = field.value;
-      return acc;
-    }, {});
+    extraInfo = contact.extraInfo.reduce<Record<string, string>>(
+      (acc, field) => {
+        acc[field.name] = field.value;
+        return acc;
+      },
+      {}
+    );
   }
 
   const view = {

--- a/backend/src/queues/campaign.ts
+++ b/backend/src/queues/campaign.ts
@@ -7,6 +7,7 @@ import { AnyMessageContent } from "libzapitu-rf";
 import Campaign from "../models/Campaign";
 import ContactList from "../models/ContactList";
 import ContactListItem from "../models/ContactListItem";
+import Contact from "../models/Contact";
 import CampaignSetting from "../models/CampaignSetting";
 import CampaignShipping from "../models/CampaignShipping";
 import Whatsapp from "../models/Whatsapp";
@@ -20,6 +21,7 @@ import { parseToMilliseconds } from "../helpers/parseToMilliseconds";
 import GetWhatsappWbot from "../helpers/GetWhatsappWbot";
 import OutOfTicketMessage from "../models/OutOfTicketMessages";
 import { Session } from "../libs/wbot";
+import { mustacheValues } from "../helpers/Mustache";
 
 const connection = process.env.REDIS_URI || "";
 export const campaignQueue = new Queue("CampaignQueue", connection);
@@ -33,6 +35,19 @@ interface DispatchCampaignData {
   campaignId: number;
   campaignShippingId: number;
   contactListItemId: number;
+}
+
+interface CampaignVariable {
+  key: string;
+  value: string;
+}
+
+interface PreparedCampaignShipping {
+  number: string;
+  contactId: number;
+  campaignId: number;
+  message?: string;
+  confirmationMessage?: string;
 }
 
 async function handleVerifyCampaigns() {
@@ -113,7 +128,7 @@ async function getSettings(campaign) {
   let messageInterval = 20;
   let longerIntervalAfter = 20;
   let greaterInterval = 60;
-  let variables: any[] = [];
+  let variables: CampaignVariable[] = [];
 
   settings.forEach(setting => {
     if (setting.key === "messageInterval") {
@@ -138,8 +153,8 @@ async function getSettings(campaign) {
   };
 }
 
-function getCampaignValidMessages(campaign) {
-  const messages = [];
+function getCampaignValidMessages(campaign): string[] {
+  const messages: string[] = [];
 
   if (!isEmpty(campaign.message1) && !isNil(campaign.message1)) {
     messages.push(campaign.message1);
@@ -164,8 +179,8 @@ function getCampaignValidMessages(campaign) {
   return messages;
 }
 
-function getCampaignValidConfirmationMessages(campaign) {
-  const messages = [];
+function getCampaignValidConfirmationMessages(campaign): string[] {
+  const messages: string[] = [];
 
   if (
     !isEmpty(campaign.confirmationMessage1) &&
@@ -205,29 +220,157 @@ function getCampaignValidConfirmationMessages(campaign) {
   return messages;
 }
 
-function getProcessedMessage(msg: string, variables: any[], contact: any) {
-  let finalMessage = msg;
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 
-  if (finalMessage.includes("{nome}")) {
-    finalMessage = finalMessage.replace(/{nome}/g, contact.name);
+function extractCampaignTokens(body: string): string[] {
+  const matches = body.match(/{[^{}]+}/g);
+
+  if (!matches) {
+    return [];
   }
 
-  if (finalMessage.includes("{email}")) {
-    finalMessage = finalMessage.replace(/{email}/g, contact.email);
+  return [...new Set(matches.map(token => token.slice(1, -1)))];
+}
+
+function buildCampaignNativeValues(
+  contact: Contact | ContactListItem
+): Record<string, string> {
+  const resolvedValues = mustacheValues(undefined, contact);
+  const name = contact?.name || contact?.number || "{nome}";
+  const firstname = contact?.name
+    ? contact.name.trim().split(" ")[0]
+    : contact?.number || "{primeiro_nome}";
+  const email = contact?.email || "{email}";
+  const number = contact?.number || "{numero}";
+  const date = new Date().toLocaleDateString("en-GB");
+  const greeting =
+    typeof resolvedValues.greeting === "string"
+      ? resolvedValues.greeting
+      : "{saudacao}";
+  const time =
+    typeof resolvedValues.time === "string" ? resolvedValues.time : "{hora}";
+
+  return {
+    nome: name,
+    name,
+    primeiro_nome: firstname,
+    firstname,
+    email,
+    numero: number,
+    number,
+    telefone: number,
+    phone: number,
+    saudacao: greeting,
+    greeting,
+    hora: time,
+    time,
+    data: date,
+    date
+  };
+}
+
+function buildCampaignCustomVariableEntries(variables: CampaignVariable[]) {
+  return variables
+    .filter(variable => variable?.key)
+    .map(variable => [variable.key, variable.value ?? ""] as [string, string]);
+}
+
+function buildCampaignExtraInfoEntries(contact: Contact | null) {
+  if (!contact?.extraInfo?.length) {
+    return [] as [string, string][];
   }
 
-  if (finalMessage.includes("{numero}")) {
-    finalMessage = finalMessage.replace(/{numero}/g, contact.number);
-  }
+  const uniqueEntries = new Map<string, string>();
 
-  variables.forEach(variable => {
-    if (finalMessage.includes(`{${variable.key}}`)) {
-      const regex = new RegExp(`{${variable.key}}`, "g");
-      finalMessage = finalMessage.replace(regex, variable.value);
+  contact.extraInfo.forEach(field => {
+    const key = field?.name?.trim();
+
+    if (!key || uniqueEntries.has(key)) {
+      return;
     }
+
+    uniqueEntries.set(key, field.value ?? "");
+  });
+
+  return Array.from(uniqueEntries.entries());
+}
+
+async function findCampaignContact(
+  companyId: number,
+  contact: ContactListItem
+): Promise<Contact | null> {
+  if (!contact?.number) {
+    return null;
+  }
+
+  return Contact.findOne({
+    where: {
+      companyId,
+      number: contact.number
+    },
+    include: ["extraInfo"]
+  });
+}
+
+function replaceCampaignTokens(
+  body: string,
+  replacementEntries: [string, string][]
+) {
+  let finalMessage = body;
+
+  replacementEntries.forEach(([key, value]) => {
+    if (!key) {
+      return;
+    }
+
+    const regex = new RegExp(`\\{${escapeRegExp(key)}\\}`, "g");
+    finalMessage = finalMessage.replace(regex, value ?? "");
   });
 
   return finalMessage;
+}
+
+async function getProcessedMessage(
+  msg: string,
+  variables: CampaignVariable[],
+  contact: ContactListItem,
+  companyId: number
+) {
+  let nativeValues = buildCampaignNativeValues(contact);
+  const customVariableEntries = buildCampaignCustomVariableEntries(variables);
+  const requestedTokens = extractCampaignTokens(msg);
+  const knownTokenNames = new Set([
+    ...Object.keys(nativeValues),
+    ...customVariableEntries.map(([key]) => key)
+  ]);
+
+  let extraInfoEntries: [string, string][] = [];
+
+  const shouldLoadContactRecord = requestedTokens.some(
+    token =>
+      token === "saudacao" ||
+      token === "greeting" ||
+      !knownTokenNames.has(token)
+  );
+
+  if (shouldLoadContactRecord) {
+    const contactRecord = await findCampaignContact(companyId, contact);
+
+    if (contactRecord) {
+      nativeValues = buildCampaignNativeValues(contactRecord);
+      extraInfoEntries = buildCampaignExtraInfoEntries(contactRecord).filter(
+        ([key]) => !(key in nativeValues) && !knownTokenNames.has(key)
+      );
+    }
+  }
+
+  return replaceCampaignTokens(msg, [
+    ...Object.entries(nativeValues),
+    ...customVariableEntries,
+    ...extraInfoEntries
+  ]);
 }
 
 async function verifyAndFinalizeCampaign(campaign: Campaign) {
@@ -243,23 +386,25 @@ async function verifyAndFinalizeCampaign(campaign: Campaign) {
 
 async function prepareContact(
   campaign: Campaign,
-  variables: any[],
+  variables: CampaignVariable[],
   contact: ContactListItem,
   delay: number,
-  messages: string | any[],
-  confirmationMessages: string | any[]
+  messages: string[],
+  confirmationMessages: string[]
 ) {
-  const campaignShipping: any = {};
-  campaignShipping.number = contact.number;
-  campaignShipping.contactId = contact.id;
-  campaignShipping.campaignId = campaign.id;
+  const campaignShipping: PreparedCampaignShipping = {
+    number: contact.number,
+    contactId: contact.id,
+    campaignId: campaign.id
+  };
 
   if (messages.length) {
     const radomIndex = randomValue(0, messages.length);
-    const message = getProcessedMessage(
+    const message = await getProcessedMessage(
       messages[radomIndex],
       variables,
-      contact
+      contact,
+      campaign.companyId
     );
     campaignShipping.message = `${message}`;
   }
@@ -267,10 +412,11 @@ async function prepareContact(
   if (campaign.confirmation) {
     if (confirmationMessages.length) {
       const radomIndex = randomValue(0, confirmationMessages.length);
-      const message = getProcessedMessage(
+      const message = await getProcessedMessage(
         confirmationMessages[radomIndex],
         variables,
-        contact
+        contact,
+        campaign.companyId
       );
       campaignShipping.confirmationMessage = `${message}`;
     }

--- a/backend/src/routes/contactRoutes.ts
+++ b/backend/src/routes/contactRoutes.ts
@@ -43,6 +43,13 @@ contactRoutes.get(
 );
 
 contactRoutes.get(
+  "/contacts/extra-fields",
+  apiTokenAuth,
+  isAuth,
+  ContactController.listExtraFieldNames
+);
+
+contactRoutes.get(
   "/contacts/:contactId",
   apiTokenAuth,
   isAuth,

--- a/backend/src/services/ContactServices/ListExtraFieldNamesService.ts
+++ b/backend/src/services/ContactServices/ListExtraFieldNamesService.ts
@@ -1,0 +1,30 @@
+import Contact from "../../models/Contact";
+import ContactCustomField from "../../models/ContactCustomField";
+
+type RawExtraFieldName = {
+  name: string;
+};
+
+const ListExtraFieldNamesService = async (
+  companyId: number
+): Promise<string[]> => {
+  const records = (await ContactCustomField.findAll({
+    attributes: ["name"],
+    include: [
+      {
+        model: Contact,
+        as: "contact",
+        attributes: [],
+        where: { companyId }
+      }
+    ],
+    group: ["ContactCustomField.name"],
+    raw: true
+  })) as RawExtraFieldName[];
+
+  return [
+    ...new Set(records.map(record => record?.name?.trim()).filter(Boolean))
+  ].sort((left, right) => left.localeCompare(right));
+};
+
+export default ListExtraFieldNamesService;

--- a/frontend/src/components/CampaignModal/index.js
+++ b/frontend/src/components/CampaignModal/index.js
@@ -148,11 +148,15 @@ const CampaignModal = ({
   const [confirmationOpen, setConfirmationOpen] = useState(false);
   const [campaignEditable, setCampaignEditable] = useState(true);
   const [campaignSettingsVariables, setCampaignSettingsVariables] = useState([]);
+  const [contactExtraFieldNames, setContactExtraFieldNames] = useState([]);
   const attachmentFile = useRef(null);
   const messageInputRefs = useRef({});
   const campaignVariableCatalog = useMemo(() => {
-    return buildCampaignVariableCatalog(campaignSettingsVariables);
-  }, [campaignSettingsVariables]);
+    return buildCampaignVariableCatalog(
+      campaignSettingsVariables,
+      contactExtraFieldNames
+    );
+  }, [campaignSettingsVariables, contactExtraFieldNames]);
 
   useEffect(() => {
     return () => {
@@ -178,7 +182,16 @@ const CampaignModal = ({
 
       api
         .get("/campaign-settings")
-        .then(({ data }) => setCampaignSettingsVariables(getCampaignSettingVariables(data)));
+        .then(({ data }) =>
+          setCampaignSettingsVariables(getCampaignSettingVariables(data))
+        );
+
+      api
+        .get("/contacts/extra-fields")
+        .then(({ data }) =>
+          setContactExtraFieldNames(Array.isArray(data) ? data : [])
+        )
+        .catch(() => setContactExtraFieldNames([]));
 
       if (!campaignId) return;
 

--- a/frontend/src/components/CampaignModal/index.js
+++ b/frontend/src/components/CampaignModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useContext } from "react";
+import React, { useState, useEffect, useMemo, useRef, useContext } from "react";
 
 import * as Yup from "yup";
 import { Formik, Form, Field } from "formik";
@@ -35,6 +35,27 @@ import {
 } from "@material-ui/core";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import ConfirmationModal from "../ConfirmationModal";
+import VariablePicker from "../VariablePicker";
+import insertTextAtCursor from "../../helpers/insertTextAtCursor";
+import { buildCampaignVariableCatalog } from "../../helpers/variableCatalog";
+
+const getCampaignSettingVariables = settings => {
+  const variablesSetting = Array.isArray(settings)
+    ? settings.find(setting => setting.key === "variables")
+    : null;
+
+  if (!variablesSetting?.value) {
+    return [];
+  }
+
+  try {
+    const parsedValue = JSON.parse(variablesSetting.value);
+
+    return Array.isArray(parsedValue) ? parsedValue : [];
+  } catch (error) {
+    return [];
+  }
+};
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -64,6 +85,18 @@ const useStyles = makeStyles(theme => ({
     left: "50%",
     marginTop: -12,
     marginLeft: -12
+  },
+  variableToolbar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1)
+  },
+  variableHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize
   }
 }));
 
@@ -114,7 +147,12 @@ const CampaignModal = ({
   const [attachment, setAttachment] = useState(null);
   const [confirmationOpen, setConfirmationOpen] = useState(false);
   const [campaignEditable, setCampaignEditable] = useState(true);
+  const [campaignSettingsVariables, setCampaignSettingsVariables] = useState([]);
   const attachmentFile = useRef(null);
+  const messageInputRefs = useRef({});
+  const campaignVariableCatalog = useMemo(() => {
+    return buildCampaignVariableCatalog(campaignSettingsVariables);
+  }, [campaignSettingsVariables]);
 
   useEffect(() => {
     return () => {
@@ -137,6 +175,10 @@ const CampaignModal = ({
       api
         .get(`/whatsapp`, { params: { companyId, session: 0 } })
         .then(({ data }) => setWhatsapps(data));
+
+      api
+        .get("/campaign-settings")
+        .then(({ data }) => setCampaignSettingsVariables(getCampaignSettingVariables(data)));
 
       if (!campaignId) return;
 
@@ -235,40 +277,119 @@ const CampaignModal = ({
     }
   };
 
-  const renderMessageField = identifier => {
+  const handleInsertVariable = (identifier, token, fieldValue, setFieldValue) => {
+    const { nextValue, nextSelectionStart, nextSelectionEnd } =
+      insertTextAtCursor(fieldValue, token, messageInputRefs.current[identifier]);
+
+    setFieldValue(identifier, nextValue);
+
+    requestAnimationFrame(() => {
+      const input = messageInputRefs.current[identifier];
+
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+
+      if (typeof input.setSelectionRange === "function") {
+        input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+      }
+    });
+  };
+
+  const renderVariableToolbar = (identifier, values, setFieldValue) => {
     return (
-      <Field
-        as={TextField}
-        id={identifier}
-        name={identifier}
-        spellCheck={true}
-        fullWidth
-        rows={5}
-        label={i18n.t(`campaigns.dialog.form.${identifier}`)}
-        placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
-        multiline={true}
-        variant="outlined"
-        helperText="Utilize variáveis como {nome}, {numero}, {email} ou defina variáveis personalziadas."
-        disabled={!campaignEditable && campaign.status !== "CANCELADA"}
-      />
+      <div className={classes.variableToolbar}>
+        <VariablePicker
+          items={campaignVariableCatalog}
+          onSelectVariable={token =>
+            handleInsertVariable(
+              identifier,
+              token,
+              values[identifier],
+              setFieldValue
+            )
+          }
+          buttonLabel="{ }"
+          buttonAriaLabel={i18n.t("settings.mustacheVariables.title")}
+          menuTitle={i18n.t("settings.mustacheVariables.title")}
+        />
+        <span className={classes.variableHint}>
+          {i18n.t("settings.mustacheVariables.title")}{" "}
+          {campaignVariableCatalog.map(variable => variable.token).join(" ")}
+        </span>
+      </div>
     );
   };
 
-  const renderConfirmationMessageField = identifier => {
+  const renderMessageField = ({
+    identifier,
+    touched,
+    errors,
+    handleBlur,
+    setFieldValue,
+    values
+  }) => {
     return (
-      <Field
-        as={TextField}
-        id={identifier}
-        name={identifier}
-        spellCheck={true}
-        fullWidth
-        rows={5}
-        label={i18n.t(`campaigns.dialog.form.${identifier}`)}
-        placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
-        multiline={true}
-        variant="outlined"
-        disabled={!campaignEditable && campaign.status !== "CANCELADA"}
-      />
+      <>
+        <TextField
+          id={identifier}
+          name={identifier}
+          spellCheck={true}
+          fullWidth
+          rows={5}
+          label={i18n.t(`campaigns.dialog.form.${identifier}`)}
+          placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
+          multiline={true}
+          variant="outlined"
+          value={values[identifier] || ""}
+          onChange={event => setFieldValue(identifier, event.target.value)}
+          onBlur={handleBlur}
+          error={touched[identifier] && Boolean(errors[identifier])}
+          helperText={touched[identifier] && errors[identifier]}
+          disabled={!campaignEditable && campaign.status !== "CANCELADA"}
+          inputRef={input => {
+            messageInputRefs.current[identifier] = input;
+          }}
+        />
+        {renderVariableToolbar(identifier, values, setFieldValue)}
+      </>
+    );
+  };
+
+  const renderConfirmationMessageField = ({
+    identifier,
+    touched,
+    errors,
+    handleBlur,
+    setFieldValue,
+    values
+  }) => {
+    return (
+      <>
+        <TextField
+          id={identifier}
+          name={identifier}
+          spellCheck={true}
+          fullWidth
+          rows={5}
+          label={i18n.t(`campaigns.dialog.form.${identifier}`)}
+          placeholder={i18n.t("campaigns.dialog.form.messagePlaceholder")}
+          multiline={true}
+          variant="outlined"
+          value={values[identifier] || ""}
+          onChange={event => setFieldValue(identifier, event.target.value)}
+          onBlur={handleBlur}
+          error={touched[identifier] && Boolean(errors[identifier])}
+          helperText={touched[identifier] && errors[identifier]}
+          disabled={!campaignEditable && campaign.status !== "CANCELADA"}
+          inputRef={input => {
+            messageInputRefs.current[identifier] = input;
+          }}
+        />
+        {renderVariableToolbar(identifier, values, setFieldValue)}
+      </>
     );
   };
 
@@ -340,7 +461,14 @@ const CampaignModal = ({
             }, 400);
           }}
         >
-          {({ values, errors, touched, isSubmitting }) => (
+          {({
+            values,
+            errors,
+            touched,
+            handleBlur,
+            isSubmitting,
+            setFieldValue
+          }) => (
             <Form>
               <DialogContent dividers>
                 <Grid spacing={2} container>
@@ -493,18 +621,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message1")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message1",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage1"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage1",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message1")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message1",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -513,18 +664,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message2")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message2",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage2"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage2",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message2")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message2",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -533,18 +707,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message3")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message3",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage3"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage3",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message3")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message3",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -553,18 +750,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message4")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message4",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage4"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage4",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message4")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message4",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}
@@ -573,18 +793,41 @@ const CampaignModal = ({
                           {values.confirmation ? (
                             <Grid spacing={2} container>
                               <Grid xs={12} md={8} item>
-                                <>{renderMessageField("message5")}</>
+                                <>
+                                  {renderMessageField({
+                                    identifier: "message5",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
+                                </>
                               </Grid>
                               <Grid xs={12} md={4} item>
                                 <>
-                                  {renderConfirmationMessageField(
-                                    "confirmationMessage5"
-                                  )}
+                                  {renderConfirmationMessageField({
+                                    identifier: "confirmationMessage5",
+                                    touched,
+                                    errors,
+                                    handleBlur,
+                                    setFieldValue,
+                                    values
+                                  })}
                                 </>
                               </Grid>
                             </Grid>
                           ) : (
-                            <>{renderMessageField("message5")}</>
+                            <>
+                              {renderMessageField({
+                                identifier: "message5",
+                                touched,
+                                errors,
+                                handleBlur,
+                                setFieldValue,
+                                values
+                              })}
+                            </>
                           )}
                         </>
                       )}

--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useContext } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 
 import * as Yup from "yup";
 import { Formik, Form, Field } from "formik";
@@ -24,6 +24,9 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import moment from "moment";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import { isArray, capitalize } from "lodash";
+import VariablePicker from "../VariablePicker";
+import insertTextAtCursor from "../../helpers/insertTextAtCursor";
+import { scheduleVariableCatalog } from "../../helpers/variableCatalog";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -52,6 +55,18 @@ const useStyles = makeStyles(theme => ({
   formControl: {
     margin: theme.spacing(1),
     minWidth: 120
+  },
+  variableToolbar: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: theme.spacing(1),
+    marginTop: theme.spacing(1)
+  },
+  variableHint: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.caption.fontSize
   }
 }));
 
@@ -90,6 +105,7 @@ const ScheduleModal = ({
   const [schedule, setSchedule] = useState(initialState);
   const [currentContact, setCurrentContact] = useState(initialContact);
   const [contacts, setContacts] = useState([initialContact]);
+  const bodyInputRef = useRef(null);
 
   useEffect(() => {
     if (contactId && contacts.length) {
@@ -167,6 +183,30 @@ const ScheduleModal = ({
     handleClose();
   };
 
+  const handleInsertVariable = (token, bodyValue, setFieldValue) => {
+    const {
+      nextValue,
+      nextSelectionStart,
+      nextSelectionEnd
+    } = insertTextAtCursor(bodyValue, token, bodyInputRef.current);
+
+    setFieldValue("body", nextValue);
+
+    requestAnimationFrame(() => {
+      const input = bodyInputRef.current;
+
+      if (!input) {
+        return;
+      }
+
+      input.focus();
+
+      if (typeof input.setSelectionRange === "function") {
+        input.setSelectionRange(nextSelectionStart, nextSelectionEnd);
+      }
+    });
+  };
+
   return (
     <div className={classes.root}>
       <Dialog
@@ -192,7 +232,14 @@ const ScheduleModal = ({
             }, 400);
           }}
         >
-          {({ touched, errors, isSubmitting, values }) => (
+          {({
+            touched,
+            errors,
+            handleBlur,
+            isSubmitting,
+            setFieldValue,
+            values
+          }) => (
             <Form>
               <DialogContent dividers>
                 <div className={classes.multFieldLine}>
@@ -214,7 +261,7 @@ const ScheduleModal = ({
                         <TextField
                           {...params}
                           variant="outlined"
-                          placeholder="Contato"
+                          placeholder={i18n.t("scheduleModal.form.contact")}
                         />
                       )}
                     />
@@ -222,18 +269,37 @@ const ScheduleModal = ({
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>
-                  <Field
-                    as={TextField}
+                  <TextField
                     rows={9}
                     multiline={true}
                     label={i18n.t("scheduleModal.form.body")}
                     name="body"
+                    value={values.body}
+                    onChange={event => setFieldValue("body", event.target.value)}
+                    onBlur={handleBlur}
                     error={touched.body && Boolean(errors.body)}
                     helperText={touched.body && errors.body}
                     variant="outlined"
                     margin="dense"
                     fullWidth
+                    inputRef={bodyInputRef}
                   />
+                </div>
+                <div className={classes.variableToolbar}>
+                  <VariablePicker
+                    items={scheduleVariableCatalog}
+                    onSelectVariable={token =>
+                      handleInsertVariable(token, values.body, setFieldValue)
+                    }
+                    buttonAriaLabel={i18n.t("settings.mustacheVariables.title")}
+                    menuTitle={i18n.t("settings.mustacheVariables.title")}
+                  />
+                  <span className={classes.variableHint}>
+                    {i18n.t("settings.mustacheVariables.title")}{" "}
+                    {scheduleVariableCatalog
+                      .map(variable => variable.token)
+                      .join(" ")}
+                  </span>
                 </div>
                 <br />
                 <div className={classes.multFieldLine}>

--- a/frontend/src/components/VariablePicker/index.js
+++ b/frontend/src/components/VariablePicker/index.js
@@ -1,0 +1,66 @@
+import React, { useState } from "react";
+
+import Button from "@material-ui/core/Button";
+import ListSubheader from "@material-ui/core/ListSubheader";
+import Menu from "@material-ui/core/Menu";
+import MenuItem from "@material-ui/core/MenuItem";
+
+const VariablePicker = ({
+  items,
+  onSelectVariable,
+  buttonLabel = "{{ }}",
+  buttonAriaLabel,
+  menuTitle
+}) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleOpen = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSelect = token => {
+    onSelectVariable(token);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Button
+        type="button"
+        size="small"
+        variant="outlined"
+        aria-label={buttonAriaLabel}
+        onClick={handleOpen}
+      >
+        {buttonLabel}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+        getContentAnchorEl={null}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left"
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left"
+        }}
+      >
+        {menuTitle ? <ListSubheader disableSticky>{menuTitle}</ListSubheader> : null}
+        {items.map(item => (
+          <MenuItem key={item.token} onClick={() => handleSelect(item.token)}>
+            {item.label || item.token}
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+};
+
+export default VariablePicker;

--- a/frontend/src/helpers/insertTextAtCursor.js
+++ b/frontend/src/helpers/insertTextAtCursor.js
@@ -1,0 +1,28 @@
+const insertTextAtCursor = (currentValue = "", textToInsert = "", input) => {
+  const safeValue = currentValue || "";
+
+  if (
+    !input ||
+    typeof input.selectionStart !== "number" ||
+    typeof input.selectionEnd !== "number"
+  ) {
+    const nextValue = `${safeValue}${textToInsert}`;
+
+    return {
+      nextValue,
+      nextSelectionStart: nextValue.length,
+      nextSelectionEnd: nextValue.length
+    };
+  }
+
+  const nextValue = `${safeValue.slice(0, input.selectionStart)}${textToInsert}${safeValue.slice(input.selectionEnd)}`;
+  const nextSelectionStart = input.selectionStart + textToInsert.length;
+
+  return {
+    nextValue,
+    nextSelectionStart,
+    nextSelectionEnd: nextSelectionStart
+  };
+};
+
+export default insertTextAtCursor;

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -9,20 +9,37 @@ export const scheduleVariableCatalog = [
 
 export const campaignNativeVariableCatalog = [
   { token: "{nome}" },
+  { token: "{primeiro_nome}" },
   { token: "{numero}" },
-  { token: "{email}" }
+  { token: "{email}" },
+  { token: "{saudacao}" },
+  { token: "{hora}" },
+  { token: "{data}" }
 ];
 
-export const buildCampaignVariableCatalog = (variables = []) => {
+export const buildCampaignVariableCatalog = (
+  variables = [],
+  extraFieldNames = []
+) => {
   const customVariables = variables
     .filter(variable => variable?.key)
     .map(variable => ({
       token: `{${variable.key}}`
     }));
 
+  const extraFieldVariables = extraFieldNames
+    .filter(Boolean)
+    .map(name => ({
+      token: `{${name}}`
+    }));
+
   const uniqueTokens = new Set();
 
-  return [...campaignNativeVariableCatalog, ...customVariables].filter(item => {
+  return [
+    ...campaignNativeVariableCatalog,
+    ...customVariables,
+    ...extraFieldVariables
+  ].filter(item => {
     if (uniqueTokens.has(item.token)) {
       return false;
     }

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -1,0 +1,8 @@
+export const scheduleVariableCatalog = [
+  { token: "{{firstname}}" },
+  { token: "{{name}}" },
+  { token: "{{email}}" },
+  { token: "{{greeting}}" },
+  { token: "{{user}}" },
+  { token: "{{time}}" }
+];

--- a/frontend/src/helpers/variableCatalog.js
+++ b/frontend/src/helpers/variableCatalog.js
@@ -6,3 +6,28 @@ export const scheduleVariableCatalog = [
   { token: "{{user}}" },
   { token: "{{time}}" }
 ];
+
+export const campaignNativeVariableCatalog = [
+  { token: "{nome}" },
+  { token: "{numero}" },
+  { token: "{email}" }
+];
+
+export const buildCampaignVariableCatalog = (variables = []) => {
+  const customVariables = variables
+    .filter(variable => variable?.key)
+    .map(variable => ({
+      token: `{${variable.key}}`
+    }));
+
+  const uniqueTokens = new Set();
+
+  return [...campaignNativeVariableCatalog, ...customVariables].filter(item => {
+    if (uniqueTokens.has(item.token)) {
+      return false;
+    }
+
+    uniqueTokens.add(item.token);
+    return true;
+  });
+};


### PR DESCRIPTION
## Objetivo

Entregar a quarta parte da issue #337, expandindo o suporte de variáveis no fluxo de campanhas além da compatibilidade inicial publicada na PR #490.

## O que foi alterado

### Backend

- expansão do processamento de campanhas para resolver novas variáveis nativas de campanha, mantendo compatibilidade com `{nome}`, `{numero}`, `{email}` e variáveis customizadas já existentes
- suporte adicional para `{primeiro_nome}`, `{saudacao}`, `{hora}` e `{data}`
- resolução dinâmica de campos extras do contato quando a mensagem contém tokens que não pertencem ao conjunto nativo/customizado
- nova rota `GET /contacts/extra-fields` para listar os nomes de campos extras disponíveis por empresa e alimentar o picker no frontend

### Frontend

- ampliação do catálogo da Caixa de Variáveis em campanhas com os novos tokens nativos
- carregamento dos nomes de campos extras de contato para exibir esses tokens diretamente no picker de campanhas
- preservação da UX introduzida na PR #490, agora com um conjunto mais amplo de variáveis válidas

## Escopo funcional

- esta PR expande campanhas com variáveis baseadas em dados realmente disponíveis no momento do disparo
- por isso, o escopo desta parte ficou em dados do próprio contato, data/hora e campos extras do contato
- variáveis dependentes de ticket não foram expostas aqui porque campanhas não possuem contexto de ticket no envio e isso geraria tokens enganosos

## Compatibilidade

- tokens legados de campanhas continuam funcionando
- variáveis customizadas de `CampaignSettings` continuam com prioridade preservada
- quando houver um contato real correspondente ao item da lista, campos extras também podem ser resolvidos no backend e exibidos no picker

## Observação de base

- esta branch foi construída sobre a PR #490, que já adiciona a Caixa de Variáveis ao modal de campanhas
- como a conta autenticada tem permissão READ no repositório oficial, não foi possível publicar uma branch-base diretamente em `ticketz-oss/ticketz`
- por isso, esta PR foi aberta contra `main` e ainda inclui a base da #490 no diff enquanto ela não for mergeada

## Validação executada

- `npm run devbuild` em `backend/`
- `npx eslint src/queues/campaign.ts src/helpers/Mustache.ts src/controllers/ContactController.ts src/routes/contactRoutes.ts src/services/ContactServices/ListExtraFieldNamesService.ts` em `backend/`
- `npx eslint src/components/CampaignModal/index.js src/helpers/variableCatalog.js` em `frontend/`
- diagnóstico sem erros nos arquivos alterados via `get_errors`

## Relações

- Relacionada: https://github.com/ticketz-oss/ticketz/issues/337
- Dependência funcional: https://github.com/ticketz-oss/ticketz/pull/490
- Base reutilizável original: https://github.com/ticketz-oss/ticketz/pull/488