### PR TITLE
feat: notify configured number when ticket falls out of business hours

### DIFF
--- a/backend/src/services/WbotServices/wbotMessageListener.ts
+++ b/backend/src/services/WbotServices/wbotMessageListener.ts
@@ -1176,6 +1176,42 @@ const sendMenu = async (
   botText();
 };
 
+const notifyOutOfHoursContact = async (
+  wbot: Session,
+  ticket: Ticket,
+  contact: Contact,
+  bodyMessage?: string
+) => {
+  const notifyNumber = await GetCompanySetting(
+    ticket.companyId,
+    "outOfHoursNotifyNumber",
+    ""
+  );
+
+  const sanitizedNumber = notifyNumber?.replace(/\D/g, "");
+
+  if (!sanitizedNumber) {
+    return;
+  }
+
+  try {
+    const contactName = contact.name || contact.number;
+
+    let text = `*Mensagem recebida fora do horário de expediente*\n\nDe: ${contactName} (${contact.number})`;
+
+    if (bodyMessage?.trim()) {
+      text += `\n\nMensagem: ${bodyMessage.trim()}`;
+    }
+
+    await wbot.sendMessage(getJidOf(sanitizedNumber), { text });
+  } catch (error) {
+    logger.error(
+      { error },
+      "Error sending out-of-hours notification message"
+    );
+  }
+};
+
 export const startQueue = async (
   wbot: Session,
   ticket: Ticket,
@@ -1254,6 +1290,7 @@ export const startQueue = async (
         text: formatBody(outOfHoursMessage, ticket)
       });
       await verifyMessage(sentMessage, ticket, contact);
+      await notifyOutOfHoursContact(wbot, ticket, contact, ticket.lastMessage);
       const outOfHoursAction = await GetCompanySetting(
         companyId,
         "outOfHoursAction",
@@ -1962,6 +1999,12 @@ const handleMessage = async (
                 text: formatBody(outOfHoursMessage, ticket)
               });
               await verifyMessage(sentMessage, ticket, ticket.contact);
+              await notifyOutOfHoursContact(
+                wbot,
+                ticket,
+                ticket.contact,
+                bodyMessage
+              );
             }
             if (ticket.status !== "open") {
               await UpdateTicketService({
@@ -1998,6 +2041,12 @@ const handleMessage = async (
                 text: formatBody(outOfHoursMessage, ticket)
               });
               await verifyMessage(sentMessage, ticket, ticket.contact);
+              await notifyOutOfHoursContact(
+                wbot,
+                ticket,
+                ticket.contact,
+                bodyMessage
+              );
             }
             if (ticket.status !== "open") {
               await UpdateTicketService({

--- a/frontend/src/components/Settings/Options.js
+++ b/frontend/src/components/Settings/Options.js
@@ -97,6 +97,7 @@ export default function Options(props) {
   const [userRating, setUserRating] = useState("disabled");
   const [scheduleType, setScheduleType] = useState("disabled");
   const [outOfHoursAction, setOutOfHoursAction] = useState("pending");
+  const [outOfHoursNotifyNumber, setOutOfHoursNotifyNumber] = useState("");
   const [callType, setCallType] = useState("enabled");
   const [quickMessages, setQuickMessages] = useState("");
   const [defaultLanguage, setDefaultLanguage] = useState("");
@@ -168,6 +169,11 @@ export default function Options(props) {
 
       const outOfHoursAction = settings.find(s => s.key === "outOfHoursAction");
       setOutOfHoursAction(outOfHoursAction?.value || "pending");
+
+      const outOfHoursNotifyNumber = settings.find(
+        s => s.key === "outOfHoursNotifyNumber"
+      );
+      setOutOfHoursNotifyNumber(outOfHoursNotifyNumber?.value || "");
 
       const callType = settings.find(s => s.key === "call");
       if (callType) {
@@ -854,6 +860,24 @@ export default function Options(props) {
                 {i18n.t("settings.outOfHoursAction.options.closed")}
               </MenuItem>
             </Select>
+          </FormControl>
+        </Grid>
+
+        <Grid xs={12} sm={6} md={4} item>
+          <FormControl className={classes.selectContainer}>
+            <TextField
+              id="out-of-hours-notify-number-field"
+              label={i18n.t("settings.outOfHoursNotifyNumber.title")}
+              placeholder={i18n.t("settings.outOfHoursNotifyNumber.placeholder")}
+              variant="standard"
+              value={outOfHoursNotifyNumber}
+              onChange={e => {
+                setOutOfHoursNotifyNumber(e.target.value);
+              }}
+              onBlur={() => {
+                handleSetting("outOfHoursNotifyNumber", outOfHoursNotifyNumber);
+              }}
+            />
           </FormControl>
         </Grid>
 

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -896,6 +896,10 @@ const messages = {
             closed: "Close ticket"
           }
         },
+        outOfHoursNotifyNumber: {
+          title: "Out of hours notify number",
+          placeholder: "E.g.: 5511999999999"
+        },
         IgnoreGroupMessages: {
           title: "Ignore Group Messages",
           options: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -896,6 +896,10 @@ const messages = {
             closed: "Cerrar ticket"
           }
         },
+        outOfHoursNotifyNumber: {
+          title: "Número a notificar fuera del horario",
+          placeholder: "Ej: 5511999999999"
+        },
         IgnoreGroupMessages: {
           title: "Ignorar mensajes de grupo",
           options: {

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -895,6 +895,10 @@ const messages = {
             closed: "Fechar ticket"
           }
         },
+        outOfHoursNotifyNumber: {
+          title: "Notificar nº fora do expediente",
+          placeholder: "Ex: 5511999999999"
+        },
         IgnoreGroupMessages: {
           title: "Ignorar Mensagens de Grupos",
           options: {


### PR DESCRIPTION
## Summary
- Adds a new optional global setting **Notificar nº fora do expediente** (`outOfHoursNotifyNumber`) under **Settings > Options > Horário de expediente**.
- When a contact sends a message outside business hours (queue or company schedule), in addition to the existing auto-reply, a summary message is forwarded to the configured WhatsApp number containing:
  - The contact's name and number
  - The original message body (when available)
- If the setting is empty (default), behavior is unchanged — no extra message is sent.

## Why
Companies often want an on-call/manager number to be notified in real time when a customer reaches out outside business hours, without having to monitor the helpdesk dashboard.

## Implementation
- `backend/src/services/WbotServices/wbotMessageListener.ts`: new `notifyOutOfHoursContact` helper, called from both the queue-schedule and company-schedule out-of-hours branches (in `startQueue` and `handleMessage`), right after the existing auto-reply is sent.
- `frontend/src/components/Settings/Options.js`: new text field for configuring the notify number, persisted via the existing generic Settings key/value store (no backend whitelist changes needed).
- i18n strings added to `pt`, `en`, and `es`.

## Test plan
- [x] Manually configured the setting in Settings > Options and confirmed the field saves/loads correctly.
- [x] Triggered an out-of-hours message and confirmed the auto-reply is still sent as before.
- [x] Confirmed the forwarded notification message is sent to the configured number with sender name, number, and message body.
- [ ] CI checks (lint/build) on this PR